### PR TITLE
Trim 5-piece door rails by subtracting stiles

### DIFF
--- a/lib/cabinet.rb
+++ b/lib/cabinet.rb
@@ -624,10 +624,8 @@ module AICabinets
 
     # Trim rails where they intersect stiles
     [left, right].each do |stile|
-      # Boolean subtraction deletes both operands, so subtract using
-      # temporary copies to keep the original stiles intact.
-      bottom = bottom.subtract(stile.copy) || bottom
-      top = top.subtract(stile.copy) || top
+      bottom = stile.trim(bottom) || bottom
+      top = stile.trim(top) || top
     end
 
     # Panel set in grooves; bevel run only affects the front face width


### PR DESCRIPTION
## Summary
- subtract stile geometry from top and bottom rails using boolean difference

## Testing
- `ruby -c lib/cabinet.rb`


------
https://chatgpt.com/codex/tasks/task_e_68bef874682483338eeba2e64190151c