### PR TITLE
Add cabinet panel inset options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains Ruby scripts for SketchUp that generate simple cabinetr
 
 ## Contents
 
-- `lib/cabinet.rb` – library functions for creating cabinets. The generator builds a frameless carcass from two sides, a top, a bottom, and a back, and can optionally add shelves.
+ - `lib/cabinet.rb` – library functions for creating cabinets. The generator builds a frameless carcass from two sides, a top, a bottom, and a back, and can optionally add shelves. Panels can be inset using `top_inset`, `bottom_inset`, and `back_inset` options.
 - `examples/frameless_two_shelf_cabinet.rb` – sample script that creates a frameless cabinet with two shelves.
 - `examples/shaker_door_cabinet.rb` – demonstrates a rail-and-stile door with an 18° bevel.
 - `examples/drawer_cabinet.rb` – shows how to add drawers to a cabinet, mix drawers with doors, and adjust drawer clearances.

--- a/examples/frameless_two_shelf_cabinet.rb
+++ b/examples/frameless_two_shelf_cabinet.rb
@@ -1,5 +1,6 @@
 # Example usage of the AICabinets library.
-# Creates two frameless cabinets side by side.
+# Creates two frameless cabinets side by side, demonstrating top, bottom,
+# and back insets.
 
 require_relative '../lib/cabinet'
 
@@ -9,6 +10,9 @@ AICabinets.create_frameless_cabinet(
   depth: 350.mm,
   panel_thickness: 19.mm,
   back_thickness: 6.mm,
+  top_inset: 20.mm,
+  bottom_inset: 20.mm,
+  back_inset: 10.mm,
   door_thickness: 19.mm,
   door_reveal: 2.mm,
   cabinets: [


### PR DESCRIPTION
## Summary
- allow specifying top, bottom, and back panel insets
- update shelf and drawer logic to use inset offsets
- document inset options and show example usage

## Testing
- `ruby -c lib/cabinet.rb`
- `ruby -c examples/frameless_two_shelf_cabinet.rb`
- `ruby -c examples/shaker_door_cabinet.rb`
- `ruby -c examples/drawer_cabinet.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c23e75ddd88333bd29d7db9bd05340