### PR TITLE
[docs] Add SketchUp 2026 unsigned RBZ install + loading policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ To package the extension for manual installation, run:
 zip -r aicabinets-$(ruby -e "load 'aicabinets/version.rb'; puts AICabinets::VERSION").rbz aicabinets.rb aicabinets/
 ```
 
+## Install (SketchUp 2026, unsigned RBZ)
+
+1. Open **Extension Manager** from the **Extensions** menu or its toolbar icon.
+2. Click **Install Extension…**, choose the downloaded `aicabinets-<VERSION>.rbz`, and confirm SketchUp’s warning for third-party packages. [SketchUp Help: Manually Installing Extensions](https://help.sketchup.com/en/sketchup/installing-extensions)
+3. If SketchUp 2026 blocks the load because the extension is **Unsigned**, open **Extension Manager → Settings (gear)** and review the **Loading Policy**, selecting the mode that matches your security posture. SketchUp documents the three modes—**Identified Extensions Only**, **Approve Unidentified Extensions**, and **Unrestricted**—in its [Loading Policy Preferences](https://help.sketchup.com/en/sketchup/loading-policy-preferences) guide. Changes may require restarting SketchUp before the unsigned extension loads.
+4. Only install RBZ files from sources you trust. **Unrestricted** allows all extensions and is the least secure option.
+5. Enable the extension in Extension Manager if it did not auto-activate after installation.
+
 ## Extension UI
 
 After installing the extension, launch its placeholder action from **Extensions → AI Cabinets → Insert Base Cabinet…** or by showing the **AI Cabinets** toolbar. Both entry points share the same command, which currently opens a simple placeholder message while the full cabinet insertion dialog is under development.


### PR DESCRIPTION
## Summary
- add a SketchUp 2026-specific README section covering unsigned RBZ installation through Extension Manager per documentation tone guidelines
- capture the loading policy flow, security posture reminder, and restart note so users know how to unblock unsigned extensions

Closes #29

## Testing
- not run (docs only)

## Acceptance Criteria
- [x] README renders a section titled “Install (SketchUp 2026, unsigned RBZ)” with Extension Manager install steps (README.md L33-L39)
- [x] Section directs users blocked by unsigned status to Extension Manager → Settings with loading policy summary and official link (README.md L37)
- [x] Text stays concise, version-specific, and screenshot-free while naming SketchUp 2026 (README.md L33-L39)
- [x] Added links point to the official SketchUp help pages for manual installs and loading policy (README.md L36-L37)

## References
- [SketchUp Help: Manually Installing Extensions](https://help.sketchup.com/en/sketchup/installing-extensions)
- [SketchUp Help: Loading Policy Preferences](https://help.sketchup.com/en/sketchup/loading-policy-preferences)

## Risk & Rollback
- Low; revert README.md if issues arise.

## Follow-ups
- Document signed package / Extension Warehouse distribution when available.


------
https://chatgpt.com/codex/tasks/task_e_68fc261d4698833385b53ffe7179e45e