### PR TITLE
[ui] Insert dialog parameter form with validation + unit parsing

### DIFF
--- a/aicabinets/ui/dialogs/insert_base_cabinet.css
+++ b/aicabinets/ui/dialogs/insert_base_cabinet.css
@@ -17,6 +17,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  min-height: 100%;
 }
 
 .dialog__header {
@@ -42,11 +43,92 @@ body {
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 4px;
   background-color: rgba(0, 0, 0, 0.03);
+  overflow-y: auto;
+}
+
+.form {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  color: rgba(0, 0, 0, 0.7);
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form__notice {
+  margin: 0;
+  padding: 12px 16px;
+  border: 1px solid rgba(30, 136, 229, 0.25);
+  background-color: rgba(30, 136, 229, 0.08);
+  border-radius: 4px;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.form__section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form__section-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.form__grid--columns {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  background-color: rgba(255, 255, 255, 0.95);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.form-field input[data-invalid='true'],
+.form-field select[data-invalid='true'] {
+  border-color: rgba(211, 47, 47, 0.85);
+  box-shadow: 0 0 0 1px rgba(211, 47, 47, 0.25);
+}
+
+.form-field input:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: rgba(30, 136, 229, 0.7);
+  box-shadow: 0 0 0 2px rgba(30, 136, 229, 0.2);
+}
+
+.field-help {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.field-error {
+  min-height: 1.2em;
+  margin: 0;
+  font-size: 0.85rem;
+  color: #d32f2f;
 }
 
 .dialog__footer {
@@ -63,12 +145,19 @@ body {
   background-color: rgba(255, 255, 255, 0.9);
   color: inherit;
   cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .button:hover,
 .button:focus {
   border-color: rgba(0, 0, 0, 0.4);
   outline: none;
+}
+
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  border-color: rgba(0, 0, 0, 0.15);
 }
 
 .button--primary {
@@ -83,15 +172,54 @@ body {
   border-color: #1565c0;
 }
 
+.is-hidden {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 12px;
+  }
+
+  .dialog {
+    gap: 12px;
+  }
+
+  .dialog__content {
+    padding: 12px;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
+  .dialog__subtitle {
+    color: rgba(255, 255, 255, 0.75);
+  }
+
   .dialog__content {
     border-color: rgba(255, 255, 255, 0.2);
     background-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .form__notice {
+    border-color: rgba(144, 202, 249, 0.45);
+    background-color: rgba(144, 202, 249, 0.08);
     color: rgba(255, 255, 255, 0.8);
   }
 
-  .dialog__subtitle {
-    color: rgba(255, 255, 255, 0.75);
+  .field-help {
+    color: rgba(255, 255, 255, 0.65);
+  }
+
+  .form-field input,
+  .form-field select {
+    background-color: rgba(30, 30, 30, 0.9);
+    border-color: rgba(255, 255, 255, 0.25);
+  }
+
+  .form-field input[data-invalid='true'],
+  .form-field select[data-invalid='true'] {
+    border-color: rgba(244, 143, 177, 0.9);
+    box-shadow: 0 0 0 1px rgba(244, 143, 177, 0.35);
   }
 
   .button {
@@ -102,5 +230,10 @@ body {
   .button:hover,
   .button:focus {
     border-color: rgba(255, 255, 255, 0.4);
+  }
+
+  .button[disabled] {
+    border-color: rgba(255, 255, 255, 0.2);
+    opacity: 0.5;
   }
 }

--- a/aicabinets/ui/dialogs/insert_base_cabinet.html
+++ b/aicabinets/ui/dialogs/insert_base_cabinet.html
@@ -17,13 +17,173 @@
       </header>
 
       <main class="dialog__content" role="main">
-        <p class="dialog__placeholder">
-          Parameter controls will appear here in a future update.
-        </p>
+        <form class="form" data-role="insert-form" novalidate>
+          <p class="form__notice" data-role="units-note">
+            Values without a suffix use the model’s display unit. Examples: 600, 450mm, 2' 3-1/2", 24 in.
+          </p>
+
+          <section class="form__section">
+            <h2 class="form__section-title">Dimensions</h2>
+            <div class="form__grid">
+              <div class="form-field" data-field="width">
+                <label for="field-width">Width</label>
+                <input
+                  type="text"
+                  id="field-width"
+                  name="width"
+                  autocomplete="off"
+                  inputmode="decimal"
+                />
+                <p class="field-help">Overall cabinet width.</p>
+                <p class="field-error" data-error-for="width" aria-live="polite"></p>
+              </div>
+
+              <div class="form-field" data-field="depth">
+                <label for="field-depth">Depth</label>
+                <input
+                  type="text"
+                  id="field-depth"
+                  name="depth"
+                  autocomplete="off"
+                  inputmode="decimal"
+                />
+                <p class="field-help">Overall cabinet depth.</p>
+                <p class="field-error" data-error-for="depth" aria-live="polite"></p>
+              </div>
+
+              <div class="form-field" data-field="height">
+                <label for="field-height">Height</label>
+                <input
+                  type="text"
+                  id="field-height"
+                  name="height"
+                  autocomplete="off"
+                  inputmode="decimal"
+                />
+                <p class="field-help">Overall cabinet height.</p>
+                <p class="field-error" data-error-for="height" aria-live="polite"></p>
+              </div>
+
+              <div class="form-field" data-field="panel_thickness">
+                <label for="field-panel-thickness">Panel thickness</label>
+                <input
+                  type="text"
+                  id="field-panel-thickness"
+                  name="panel_thickness"
+                  autocomplete="off"
+                  inputmode="decimal"
+                />
+                <p class="field-help">Carcass panel thickness.</p>
+                <p class="field-error" data-error-for="panel_thickness" aria-live="polite"></p>
+              </div>
+
+              <div class="form-field" data-field="toe_kick_height">
+                <label for="field-toe-kick-height">Toe kick height</label>
+                <input
+                  type="text"
+                  id="field-toe-kick-height"
+                  name="toe_kick_height"
+                  autocomplete="off"
+                  inputmode="decimal"
+                />
+                <p class="field-help">Height of the toe kick recess.</p>
+                <p class="field-error" data-error-for="toe_kick_height" aria-live="polite"></p>
+              </div>
+
+              <div class="form-field" data-field="toe_kick_depth">
+                <label for="field-toe-kick-depth">Toe kick depth</label>
+                <input
+                  type="text"
+                  id="field-toe-kick-depth"
+                  name="toe_kick_depth"
+                  autocomplete="off"
+                  inputmode="decimal"
+                />
+                <p class="field-help">Depth of the toe kick recess.</p>
+                <p class="field-error" data-error-for="toe_kick_depth" aria-live="polite"></p>
+              </div>
+            </div>
+          </section>
+
+          <section class="form__section">
+            <h2 class="form__section-title">Configuration</h2>
+            <div class="form__grid form__grid--columns">
+              <div class="form-field" data-field="front">
+                <label for="field-front">Front layout</label>
+                <select id="field-front" name="front">
+                  <option value="empty">Open (no doors)</option>
+                  <option value="doors_left">Doors — left hinge</option>
+                  <option value="doors_right">Doors — right hinge</option>
+                  <option value="doors_double">Doors — double</option>
+                </select>
+                <p class="field-help">Choose the door configuration for the cabinet front.</p>
+              </div>
+
+              <div class="form-field" data-field="shelves">
+                <label for="field-shelves">Shelves</label>
+                <input
+                  type="number"
+                  id="field-shelves"
+                  name="shelves"
+                  inputmode="numeric"
+                  min="0"
+                  step="1"
+                />
+                <p class="field-help">Number of adjustable shelves.</p>
+                <p class="field-error" data-error-for="shelves" aria-live="polite"></p>
+              </div>
+            </div>
+          </section>
+
+          <section class="form__section">
+            <h2 class="form__section-title">Partitions</h2>
+            <div class="form-field" data-field="partitions_mode">
+              <label for="field-partitions-mode">Partition mode</label>
+              <select id="field-partitions-mode" name="partitions_mode">
+                <option value="none">None</option>
+                <option value="even">Even spacing</option>
+                <option value="positions">Specific positions</option>
+              </select>
+              <p class="field-help">
+                Add vertical partitions to divide the interior. Choose even spacing or provide explicit positions.
+              </p>
+            </div>
+
+            <div class="form-field is-hidden" data-field="partitions_count" data-partitions-control="even">
+              <label for="field-partitions-count">Partition count</label>
+              <input
+                type="number"
+                id="field-partitions-count"
+                name="partitions_count"
+                inputmode="numeric"
+                min="0"
+                step="1"
+              />
+              <p class="field-help">Number of evenly spaced partitions.</p>
+              <p class="field-error" data-error-for="partitions_count" aria-live="polite"></p>
+            </div>
+
+            <div class="form-field is-hidden" data-field="partitions_positions" data-partitions-control="positions">
+              <label for="field-partitions-positions">Partition positions</label>
+              <input
+                type="text"
+                id="field-partitions-positions"
+                name="partitions_positions"
+                autocomplete="off"
+                inputmode="decimal"
+                placeholder="e.g., 100mm, 250mm, 400mm"
+              />
+              <p class="field-help">
+                Comma-separated distances from the left interior wall. Values must increase and use allowed units.
+              </p>
+              <p class="field-error" data-error-for="partitions_positions" aria-live="polite"></p>
+            </div>
+          </section>
+        </form>
       </main>
 
       <footer class="dialog__footer">
-        <button type="button" class="button button--primary" data-action="insert">
+        <button type="button" class="button button--primary" data-action="insert" disabled>
           Insert
         </button>
         <button type="button" class="button" data-action="cancel">

--- a/aicabinets/ui/dialogs/insert_base_cabinet.js
+++ b/aicabinets/ui/dialogs/insert_base_cabinet.js
@@ -2,14 +2,878 @@
   'use strict';
 
   function invokeSketchUp(action, payload) {
+    if (!action) {
+      return;
+    }
+
     if (window.sketchup && typeof window.sketchup[action] === 'function') {
       window.sketchup[action](payload);
     }
   }
 
+  var root = (window.AICabinets = window.AICabinets || {});
+  var uiRoot = (root.UI = root.UI || {});
+  var namespace = (uiRoot.InsertBaseCabinet = uiRoot.InsertBaseCabinet || {});
+
+  var controller = null;
+  var pendingUnitSettings = null;
+
+  var UNIT_TO_MM = {
+    inch: 25.4,
+    foot: 304.8,
+    millimeter: 1,
+    centimeter: 10,
+    meter: 1000
+  };
+
+  var LENGTH_FIELDS = [
+    'width',
+    'depth',
+    'height',
+    'panel_thickness',
+    'toe_kick_height',
+    'toe_kick_depth'
+  ];
+
+  var INTEGER_FIELDS = ['shelves', 'partitions_count'];
+
+  function defaultLengthSettings() {
+    return {
+      unit: 'millimeter',
+      unit_label: 'mm',
+      unit_name: 'millimeters',
+      format: 'decimal',
+      precision: 0,
+      fractional_precision: 3
+    };
+  }
+
+  function normalizeLengthSettings(settings) {
+    var normalized = defaultLengthSettings();
+    if (!settings || typeof settings !== 'object') {
+      return normalized;
+    }
+
+    if (typeof settings.unit === 'string' && UNIT_TO_MM[settings.unit]) {
+      normalized.unit = settings.unit;
+    }
+
+    if (typeof settings.unit_label === 'string' && settings.unit_label.trim()) {
+      normalized.unit_label = settings.unit_label.trim();
+    } else if (normalized.unit === 'inch') {
+      normalized.unit_label = 'in';
+    } else if (normalized.unit === 'foot') {
+      normalized.unit_label = 'ft';
+    }
+
+    if (typeof settings.unit_name === 'string' && settings.unit_name.trim()) {
+      normalized.unit_name = settings.unit_name.trim();
+    } else {
+      normalized.unit_name = defaultUnitName(normalized.unit);
+    }
+
+    if (typeof settings.format === 'string') {
+      var lowered = settings.format.toLowerCase();
+      if (['architectural', 'fractional', 'decimal', 'engineering'].indexOf(lowered) !== -1) {
+        normalized.format = lowered;
+      }
+    }
+
+    if (typeof settings.precision === 'number' && isFinite(settings.precision)) {
+      var precision = Math.max(0, Math.min(6, Math.round(settings.precision)));
+      normalized.precision = precision;
+    }
+
+    if (
+      typeof settings.fractional_precision === 'number' &&
+      isFinite(settings.fractional_precision)
+    ) {
+      var frac = Math.max(0, Math.min(5, Math.round(settings.fractional_precision)));
+      normalized.fractional_precision = frac;
+    }
+
+    return normalized;
+  }
+
+  function defaultUnitName(unit) {
+    switch (unit) {
+      case 'inch':
+        return 'inches';
+      case 'foot':
+        return 'feet';
+      case 'centimeter':
+        return 'centimeters';
+      case 'meter':
+        return 'meters';
+      default:
+        return 'millimeters';
+    }
+  }
+
+  function LengthService(settings) {
+    this.settings = normalizeLengthSettings(settings);
+  }
+
+  LengthService.prototype.updateSettings = function updateSettings(settings) {
+    this.settings = normalizeLengthSettings(settings);
+  };
+
+  LengthService.prototype.parse = function parse(value) {
+    var text = String(value == null ? '' : value);
+    text = text.trim();
+    if (!text) {
+      return { ok: false, error: 'Enter a length.' };
+    }
+
+    text = text
+      .replace(/[\u2018\u2019\u2032\u00b4]/g, "'")
+      .replace(/[\u201c\u201d\u2033]/g, '"')
+      .replace(/″/g, '"')
+      .replace(/′/g, "'");
+
+    if (/^\s*-/.test(text)) {
+      return { ok: false, error: 'Length must be non-negative.' };
+    }
+
+    var footValue = parseFootAndInches(text);
+    if (footValue != null) {
+      if (!isFinite(footValue)) {
+        return { ok: false, error: 'Enter a valid length.' };
+      }
+      return { ok: true, value_mm: footValue };
+    }
+
+    var suffix = extractUnitSuffix(text);
+    var unit = suffix.unit || this.settings.unit;
+    if (!UNIT_TO_MM[unit]) {
+      unit = 'millimeter';
+    }
+
+    var numberText = suffix.text.trim();
+    if (!numberText) {
+      numberText = '0';
+    }
+
+    var numericValue = parseMixedNumber(numberText);
+    if (!isFinite(numericValue)) {
+      return { ok: false, error: 'Enter a valid length.' };
+    }
+
+    var mmValue = numericValue * UNIT_TO_MM[unit];
+    return { ok: true, value_mm: mmValue };
+  };
+
+  LengthService.prototype.format = function format(mmValue) {
+    if (typeof mmValue !== 'number' || !isFinite(mmValue)) {
+      return '';
+    }
+
+    var settings = this.settings;
+    if (settings.unit === 'inch' && (settings.format === 'fractional' || settings.format === 'architectural')) {
+      return formatFractionalInches(mmValue, settings.fractional_precision);
+    }
+
+    if (settings.unit === 'inch' && settings.format === 'engineering') {
+      var feetValue = mmValue / UNIT_TO_MM.foot;
+      return trimDecimal(feetValue, settings.precision) + ' ft';
+    }
+
+    var divisor = UNIT_TO_MM[settings.unit] || 1;
+    var decimalValue = mmValue / divisor;
+    var label = settings.unit === 'inch' ? 'in' : settings.unit_label;
+    return trimDecimal(decimalValue, settings.precision) + ' ' + label;
+  };
+
+  function parseFootAndInches(input) {
+    var normalized = input
+      .replace(/[\u2018\u2019\u2032\u00b4]/g, "'")
+      .replace(/[\u201c\u201d\u2033]/g, '"')
+      .replace(/″/g, '"')
+      .replace(/′/g, "'")
+      .replace(/\bfeet\b|\bfoot\b|\bft\b/gi, "'")
+      .replace(/\binches\b|\binch\b|\bin\b/gi, '"');
+
+    if (normalized.indexOf("'") === -1) {
+      return null;
+    }
+
+    var parts = normalized.split("'");
+    if (!parts.length) {
+      return null;
+    }
+
+    var feetText = parts[0].trim();
+    var remaining = parts.slice(1).join("'").trim();
+
+    var feetValue = 0;
+    if (feetText) {
+      feetValue = parseMixedNumber(feetText);
+      if (!isFinite(feetValue)) {
+        return NaN;
+      }
+    }
+
+    var mmValue = feetValue * UNIT_TO_MM.foot;
+
+    if (!remaining) {
+      return mmValue;
+    }
+
+    var inchesText = remaining;
+    var quoteIndex = inchesText.indexOf('"');
+    if (quoteIndex !== -1) {
+      var afterQuote = inchesText.slice(quoteIndex + 1).trim();
+      if (afterQuote) {
+        return NaN;
+      }
+      inchesText = inchesText.slice(0, quoteIndex).trim();
+    }
+
+    if (!inchesText) {
+      return mmValue;
+    }
+
+    var inchesValue = parseMixedNumber(inchesText);
+    if (!isFinite(inchesValue)) {
+      return NaN;
+    }
+
+    return mmValue + inchesValue * UNIT_TO_MM.inch;
+  }
+
+  function extractUnitSuffix(value) {
+    var text = value.trim();
+    var lower = text.toLowerCase();
+    var suffixes = [
+      { unit: 'millimeter', labels: ['millimeters', 'millimeter', 'mm'] },
+      { unit: 'centimeter', labels: ['centimeters', 'centimeter', 'cm'] },
+      { unit: 'meter', labels: ['meters', 'meter', 'm'] },
+      { unit: 'inch', labels: ['inches', 'inch', 'in'] },
+      { unit: 'foot', labels: ['feet', 'foot', 'ft'] }
+    ];
+
+    for (var i = 0; i < suffixes.length; i += 1) {
+      var entry = suffixes[i];
+      for (var j = 0; j < entry.labels.length; j += 1) {
+        var label = entry.labels[j];
+        if (lower.endsWith(label)) {
+          return {
+            unit: entry.unit,
+            text: text.slice(0, text.length - label.length)
+          };
+        }
+      }
+    }
+
+    if (text.endsWith('"')) {
+      return { unit: 'inch', text: text.slice(0, -1) };
+    }
+
+    if (text.endsWith("'")) {
+      return { unit: 'foot', text: text.slice(0, -1) };
+    }
+
+    return { unit: null, text: text };
+  }
+
+  function parseMixedNumber(text) {
+    var cleaned = text.trim();
+    if (!cleaned) {
+      return NaN;
+    }
+
+    cleaned = cleaned.replace(/\s*-\s*/g, ' ');
+    var parts = cleaned.split(/\s+/);
+    var index = 0;
+    var value = 0;
+
+    if (index < parts.length && isFraction(parts[index])) {
+      value += parseFraction(parts[index]);
+      index += 1;
+      if (index < parts.length) {
+        return NaN;
+      }
+      return value;
+    }
+
+    if (index < parts.length) {
+      var base = parseFloat(parts[index]);
+      if (!isFinite(base)) {
+        return NaN;
+      }
+      value += base;
+      index += 1;
+    }
+
+    if (index < parts.length) {
+      if (isFraction(parts[index])) {
+        value += parseFraction(parts[index]);
+        index += 1;
+      } else {
+        return NaN;
+      }
+    }
+
+    if (index !== parts.length) {
+      return NaN;
+    }
+
+    return value;
+  }
+
+  function isFraction(text) {
+    return /^(?:\d+)\s*\/\s*(?:\d+)$/.test(text);
+  }
+
+  function parseFraction(text) {
+    var match = text.match(/^(\d+)\s*\/\s*(\d+)$/);
+    if (!match) {
+      return NaN;
+    }
+
+    var numerator = parseInt(match[1], 10);
+    var denominator = parseInt(match[2], 10);
+    if (denominator === 0) {
+      return NaN;
+    }
+
+    return numerator / denominator;
+  }
+
+  function gcd(a, b) {
+    while (b) {
+      var temp = b;
+      b = a % b;
+      a = temp;
+    }
+    return a;
+  }
+
+  function formatFractionalInches(mmValue, fractionalPrecision) {
+    var totalInches = mmValue / UNIT_TO_MM.inch;
+    var denominator = Math.pow(2, fractionalPrecision + 1);
+    var whole = Math.floor(totalInches + 1e-9);
+    var remainder = totalInches - whole;
+    var numerator = Math.round(remainder * denominator);
+
+    if (numerator === denominator) {
+      whole += 1;
+      numerator = 0;
+    }
+
+    if (numerator !== 0) {
+      var divisor = gcd(numerator, denominator);
+      numerator /= divisor;
+      denominator /= divisor;
+    }
+
+    var parts = [];
+    if (whole > 0 || numerator === 0) {
+      parts.push(String(whole));
+    }
+
+    if (numerator > 0) {
+      var fractionText = numerator + '/' + denominator;
+      if (whole > 0) {
+        parts[parts.length - 1] = parts[parts.length - 1] + ' ' + fractionText;
+      } else {
+        parts.push(fractionText);
+      }
+    }
+
+    if (!parts.length) {
+      parts.push('0');
+    }
+
+    return parts.join('') + '"';
+  }
+
+  function trimDecimal(value, precision) {
+    var fixed = value.toFixed(precision);
+    if (precision === 0) {
+      return fixed;
+    }
+
+    return fixed.replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+  }
+
+  function FormController(form) {
+    this.form = form;
+    this.lengthService = new LengthService();
+    this.inputs = {};
+    this.errorElements = {};
+    this.touched = {};
+    this.values = {
+      lengths: {},
+      front: 'empty',
+      shelves: 0,
+      partitions: {
+        mode: 'none',
+        count: 0,
+        positions_mm: []
+      }
+    };
+
+    this.unitsNote = form.querySelector('[data-role="units-note"]');
+    this.insertButton = document.querySelector('button[data-action="insert"]');
+    this.partitionsEvenField = form.querySelector('[data-partitions-control="even"]');
+    this.partitionsPositionsField = form.querySelector('[data-partitions-control="positions"]');
+
+    this.initializeElements();
+    this.bindEvents();
+    this.updatePartitionMode('none');
+    this.updateInsertButtonState();
+  }
+
+  FormController.prototype.initializeElements = function initializeElements() {
+    var self = this;
+    LENGTH_FIELDS.forEach(function (name) {
+      var input = self.form.querySelector('[name="' + name + '"]');
+      self.inputs[name] = input;
+      self.errorElements[name] = self.form.querySelector('[data-error-for="' + name + '"]');
+      self.values.lengths[name] = null;
+      self.touched[name] = false;
+    });
+
+    INTEGER_FIELDS.forEach(function (name) {
+      self.inputs[name] = self.form.querySelector('[name="' + name + '"]');
+      self.errorElements[name] = self.form.querySelector('[data-error-for="' + name + '"]');
+      self.touched[name] = false;
+    });
+
+    this.inputs.front = this.form.querySelector('[name="front"]');
+    this.inputs.partitions_mode = this.form.querySelector('[name="partitions_mode"]');
+    this.inputs.partitions_positions = this.form.querySelector('[name="partitions_positions"]');
+    this.errorElements.partitions_positions = this.form.querySelector('[data-error-for="partitions_positions"]');
+    this.touched.partitions_positions = false;
+
+    if (this.inputs.shelves) {
+      this.inputs.shelves.value = '0';
+      this.values.shelves = 0;
+    }
+
+    if (this.inputs.front) {
+      this.values.front = this.inputs.front.value;
+    }
+  };
+
+  FormController.prototype.bindEvents = function bindEvents() {
+    var self = this;
+
+    LENGTH_FIELDS.forEach(function (name) {
+      var input = self.inputs[name];
+      if (!input) {
+        return;
+      }
+
+      input.addEventListener('input', function () {
+        self.handleLengthInput(name);
+      });
+
+      input.addEventListener('blur', function () {
+        self.handleLengthBlur(name);
+      });
+    });
+
+    INTEGER_FIELDS.forEach(function (name) {
+      var input = self.inputs[name];
+      if (!input) {
+        return;
+      }
+
+      input.addEventListener('input', function () {
+        self.handleIntegerInput(name);
+      });
+
+      input.addEventListener('blur', function () {
+        self.handleIntegerBlur(name);
+      });
+    });
+
+    if (this.inputs.front) {
+      this.inputs.front.addEventListener('change', function (event) {
+        self.values.front = event.target.value;
+      });
+    }
+
+    if (this.inputs.partitions_mode) {
+      this.inputs.partitions_mode.addEventListener('change', function (event) {
+        self.handlePartitionModeChange(event.target.value);
+      });
+    }
+
+    if (this.inputs.partitions_positions) {
+      this.inputs.partitions_positions.addEventListener('input', function () {
+        self.handlePartitionsPositionsInput();
+      });
+
+      this.inputs.partitions_positions.addEventListener('blur', function () {
+        self.handlePartitionsPositionsBlur();
+      });
+    }
+
+    this.form.addEventListener('submit', function (event) {
+      event.preventDefault();
+    });
+  };
+
+  FormController.prototype.setUnits = function setUnits(settings) {
+    this.lengthService.updateSettings(settings);
+    this.updateUnitsNotice();
+    this.reformatValidatedLengths();
+    this.reformatPartitionPositions();
+  };
+
+  FormController.prototype.updateUnitsNotice = function updateUnitsNotice() {
+    if (!this.unitsNote) {
+      return;
+    }
+
+    var unitName = this.lengthService.settings.unit_name;
+    this.unitsNote.textContent =
+      'Values without a suffix use the model\'s display unit (' +
+      unitName +
+      '). Examples: 600, 450mm, 2\' 3-1/2", 24 in.';
+  };
+
+  FormController.prototype.reformatValidatedLengths = function reformatValidatedLengths() {
+    var self = this;
+    LENGTH_FIELDS.forEach(function (name) {
+      var value = self.values.lengths[name];
+      if (value != null) {
+        self.inputs[name].value = self.lengthService.format(value);
+      }
+    });
+  };
+
+  FormController.prototype.reformatPartitionPositions = function reformatPartitionPositions() {
+    if (
+      this.values.partitions.mode === 'positions' &&
+      this.values.partitions.positions_mm.length &&
+      this.inputs.partitions_positions
+    ) {
+      var formatted = this.values.partitions.positions_mm.map(
+        this.lengthService.format.bind(this.lengthService)
+      );
+      this.inputs.partitions_positions.value = formatted.join(', ');
+    }
+  };
+
+  FormController.prototype.handleLengthInput = function handleLengthInput(name) {
+    var input = this.inputs[name];
+    var result = this.lengthService.parse(input.value);
+    if (result.ok) {
+      this.values.lengths[name] = result.value_mm;
+      input.dataset.mmValue = String(result.value_mm);
+      this.setFieldError(name, null, false);
+      input.removeAttribute('data-invalid');
+    } else {
+      this.values.lengths[name] = null;
+      delete input.dataset.mmValue;
+      if (this.touched[name]) {
+        this.setFieldError(name, result.error, true);
+        input.setAttribute('data-invalid', 'true');
+      } else {
+        this.setFieldError(name, null, false);
+        input.removeAttribute('data-invalid');
+      }
+    }
+
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.handleLengthBlur = function handleLengthBlur(name) {
+    this.touched[name] = true;
+    var input = this.inputs[name];
+    var result = this.lengthService.parse(input.value);
+    if (result.ok) {
+      this.values.lengths[name] = result.value_mm;
+      input.dataset.mmValue = String(result.value_mm);
+      input.value = this.lengthService.format(result.value_mm);
+      this.setFieldError(name, null, true);
+      input.removeAttribute('data-invalid');
+    } else {
+      this.values.lengths[name] = null;
+      delete input.dataset.mmValue;
+      this.setFieldError(name, result.error, true);
+      input.setAttribute('data-invalid', 'true');
+    }
+
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.handleIntegerInput = function handleIntegerInput(name) {
+    var input = this.inputs[name];
+    var result = parseNonNegativeInteger(input.value);
+    if (result.ok) {
+      this.applyIntegerValue(name, result.value);
+      this.setFieldError(name, null, false);
+      input.removeAttribute('data-invalid');
+    } else {
+      this.applyIntegerValue(name, null);
+      if (this.touched[name]) {
+        this.setFieldError(name, result.error, true);
+        input.setAttribute('data-invalid', 'true');
+      } else {
+        this.setFieldError(name, null, false);
+        input.removeAttribute('data-invalid');
+      }
+    }
+
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.handleIntegerBlur = function handleIntegerBlur(name) {
+    this.touched[name] = true;
+    var input = this.inputs[name];
+    var result = parseNonNegativeInteger(input.value);
+    if (result.ok) {
+      this.applyIntegerValue(name, result.value);
+      this.setFieldError(name, null, true);
+      input.value = String(result.value);
+      input.removeAttribute('data-invalid');
+    } else {
+      this.applyIntegerValue(name, null);
+      this.setFieldError(name, result.error, true);
+      input.setAttribute('data-invalid', 'true');
+    }
+
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.applyIntegerValue = function applyIntegerValue(name, value) {
+    if (name === 'shelves') {
+      this.values.shelves = value;
+    } else if (name === 'partitions_count') {
+      this.values.partitions.count = value;
+    }
+  };
+
+  FormController.prototype.handlePartitionModeChange = function handlePartitionModeChange(mode) {
+    this.values.partitions.mode = mode;
+    this.updatePartitionMode(mode);
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.updatePartitionMode = function updatePartitionMode(mode) {
+    if (this.partitionsEvenField) {
+      this.partitionsEvenField.classList.toggle('is-hidden', mode !== 'even');
+    }
+
+    if (this.partitionsPositionsField) {
+      this.partitionsPositionsField.classList.toggle('is-hidden', mode !== 'positions');
+    }
+
+    if (mode === 'even') {
+      this.values.partitions.count = null;
+      if (this.inputs.partitions_count) {
+        this.inputs.partitions_count.value = '';
+        this.inputs.partitions_count.removeAttribute('data-invalid');
+      }
+      this.setFieldError('partitions_count', null, true);
+      this.touched.partitions_count = false;
+    } else {
+      this.values.partitions.count = 0;
+      if (this.inputs.partitions_count) {
+        this.inputs.partitions_count.value = '';
+        this.inputs.partitions_count.removeAttribute('data-invalid');
+      }
+      this.setFieldError('partitions_count', null, true);
+      this.touched.partitions_count = false;
+    }
+
+    if (mode !== 'positions') {
+      this.values.partitions.positions_mm = [];
+      if (this.inputs.partitions_positions) {
+        this.inputs.partitions_positions.value = '';
+        this.inputs.partitions_positions.removeAttribute('data-invalid');
+      }
+      this.setFieldError('partitions_positions', null, true);
+      this.touched.partitions_positions = false;
+    }
+  };
+
+  FormController.prototype.handlePartitionsPositionsInput = function handlePartitionsPositionsInput() {
+    var input = this.inputs.partitions_positions;
+    if (!input) {
+      return;
+    }
+
+    var result = this.parsePartitionPositions(input.value);
+    if (result.ok) {
+      this.values.partitions.positions_mm = result.values_mm;
+      this.setFieldError('partitions_positions', null, false);
+      input.removeAttribute('data-invalid');
+    } else {
+      this.values.partitions.positions_mm = [];
+      if (this.touched.partitions_positions) {
+        this.setFieldError('partitions_positions', result.error, true);
+        input.setAttribute('data-invalid', 'true');
+      } else {
+        this.setFieldError('partitions_positions', null, false);
+        input.removeAttribute('data-invalid');
+      }
+    }
+
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.handlePartitionsPositionsBlur = function handlePartitionsPositionsBlur() {
+    this.touched.partitions_positions = true;
+    var input = this.inputs.partitions_positions;
+    if (!input) {
+      return;
+    }
+
+    var result = this.parsePartitionPositions(input.value);
+    if (result.ok) {
+      this.values.partitions.positions_mm = result.values_mm;
+      var formatted = result.values_mm.map(this.lengthService.format.bind(this.lengthService));
+      input.value = formatted.join(', ');
+      this.setFieldError('partitions_positions', null, true);
+      input.removeAttribute('data-invalid');
+    } else {
+      this.values.partitions.positions_mm = [];
+      this.setFieldError('partitions_positions', result.error, true);
+      input.setAttribute('data-invalid', 'true');
+    }
+
+    this.updateInsertButtonState();
+  };
+
+  FormController.prototype.parsePartitionPositions = function parsePartitionPositions(value) {
+    var raw = String(value == null ? '' : value).trim();
+    if (!raw) {
+      return { ok: false, error: 'Enter one or more positions separated by commas.' };
+    }
+
+    var tokens = raw
+      .split(/[,;]+/)
+      .map(function (token) {
+        return token.trim();
+      })
+      .filter(function (token) {
+        return token.length > 0;
+      });
+
+    if (!tokens.length) {
+      return { ok: false, error: 'Enter one or more positions separated by commas.' };
+    }
+
+    var values = [];
+    for (var i = 0; i < tokens.length; i += 1) {
+      var token = tokens[i];
+      var result = this.lengthService.parse(token);
+      if (!result.ok) {
+        return { ok: false, error: 'Position ' + (i + 1) + ': ' + result.error };
+      }
+
+      if (result.value_mm < 0) {
+        return { ok: false, error: 'Positions must be non-negative.' };
+      }
+
+      values.push(result.value_mm);
+    }
+
+    for (var j = 1; j < values.length; j += 1) {
+      if (values[j] <= values[j - 1]) {
+        return { ok: false, error: 'Positions must increase from left to right.' };
+      }
+    }
+
+    return { ok: true, values_mm: values };
+  };
+
+  FormController.prototype.setFieldError = function setFieldError(name, message, persist) {
+    if (persist === void 0) {
+      persist = true;
+    }
+
+    var element = this.errorElements[name];
+    if (!element) {
+      return;
+    }
+
+    if (message) {
+      element.textContent = message;
+    } else if (persist) {
+      element.textContent = '';
+    } else {
+      element.textContent = '';
+    }
+  };
+
+  FormController.prototype.isFormValid = function isFormValid() {
+    var allLengthsValid = LENGTH_FIELDS.every(
+      function (name) {
+        return this.values.lengths[name] != null;
+      }.bind(this)
+    );
+
+    if (!allLengthsValid) {
+      return false;
+    }
+
+    if (this.values.shelves == null) {
+      return false;
+    }
+
+    if (this.values.partitions.mode === 'even') {
+      if (this.values.partitions.count == null) {
+        return false;
+      }
+    }
+
+    if (this.values.partitions.mode === 'positions') {
+      if (!this.values.partitions.positions_mm.length) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  FormController.prototype.updateInsertButtonState = function updateInsertButtonState() {
+    if (!this.insertButton) {
+      return;
+    }
+
+    this.insertButton.disabled = !this.isFormValid();
+  };
+
+  function parseNonNegativeInteger(value) {
+    var text = String(value == null ? '' : value).trim();
+    if (!text) {
+      return { ok: false, error: 'Enter a whole number.' };
+    }
+
+    if (!/^\d+$/.test(text)) {
+      return { ok: false, error: 'Enter a whole number.' };
+    }
+
+    var number = parseInt(text, 10);
+    if (number < 0) {
+      return { ok: false, error: 'Value must be zero or greater.' };
+    }
+
+    return { ok: true, value: number };
+  }
+
+  namespace.bootstrap = function bootstrap(settings) {
+    if (controller) {
+      controller.setUnits(settings);
+    } else {
+      pendingUnitSettings = settings;
+    }
+  };
+
   function handleButtonClick(event) {
     var target = event.target;
     if (!(target instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    if (target.disabled) {
       return;
     }
 
@@ -21,5 +885,21 @@
     invokeSketchUp(action);
   }
 
+  function initialize() {
+    var form = document.querySelector('[data-role="insert-form"]');
+    if (!form) {
+      return;
+    }
+
+    controller = new FormController(form);
+    if (pendingUnitSettings) {
+      controller.setUnits(pendingUnitSettings);
+      pendingUnitSettings = null;
+    }
+
+    invokeSketchUp('dialog_ready');
+  }
+
+  document.addEventListener('DOMContentLoaded', initialize);
   document.addEventListener('click', handleButtonClick);
 })();


### PR DESCRIPTION
## Summary
- **Intent:** Present a client-side form for the Insert Base Cabinet dialog that mirrors the issue’s required parameters while reflecting the model’s units for readability.
- **Implementation:** Added structured form markup with inline help, responsive layout styling, and a JavaScript controller that parses/normalizes length inputs to millimeters, surfaces validation errors inline, and keeps the Insert button disabled until the state is valid. A Ruby bootstrap callback now publishes the model’s unit preferences so the parser/formatter can format results in the active display style.

Closes #31

## Verification
- ✅ `ruby -c aicabinets.rb && find aicabinets -type f -name '*.rb' -print0 | xargs -0 -n1 ruby -c`

## Acceptance Criteria
- [x] **Fields render:** Open the dialog and confirm every field and helper text listed in the story are visible (capture screenshot for review).

    <img width="715" height="930" alt="image" src="https://github.com/user-attachments/assets/f4ae1df5-17b2-4307-88f4-0ed36dea96eb" />

- [x] **Invalid length handling:** Enter negative or non-numeric text, blur, and confirm an inline error appears while the Insert button stays disabled (grab console log showing `data-invalid` attribute or screenshot of error state).

    <img width="293" height="168" alt="image" src="https://github.com/user-attachments/assets/a05ccbcd-30fd-41d3-b432-1821974e0dc5" />

- [x] **Architectural inches formatting:** With model units set to architectural inches, enter `600mm` and confirm the formatted display shows an inch fraction (e.g., `23 5/8"`) while the canonical mm value logged from `dataset.mmValue` ≈ 600.0.
- [x] **Metric formatting:** With model units set to millimeters, enter `23-5/8"` and confirm the field reformats to `600 mm` (display rounding) and the stored canonical value ≈ 600.08 mm.
- [x] **Even partitions validation:** Switch partitions mode to **Even**, set count to `3`, and confirm no errors remain and Insert enables once other fields are valid (console log or screenshot of enabled button).

    <img width="690" height="355" alt="image" src="https://github.com/user-attachments/assets/a84fd18a-9dbb-4ecc-aee7-1adfb775c601" />

- [x] **Partition positions parsing:** Switch partitions mode to **Positions**, enter `100mm, 250 mm, 400 mm`, and confirm the list reformats and Insert enables when all other fields validate (log canonical array in console).

    <img width="693" height="343" alt="image" src="https://github.com/user-attachments/assets/e6cc047a-5e81-40a0-ad52-b234ea54b501" />

- [x] **Error messaging guard:** While any field is invalid, hover/focus it and confirm the inline message remains visible and Insert stays disabled (screenshot showing tooltip/message).

## Rollback Plan
Revert `insert_base_cabinet.html`, `insert_base_cabinet.css`, `insert_base_cabinet.js`, and `insert_base_cabinet_dialog.rb` to their prior versions to remove the form, validation logic, and units bootstrap.

## Follow-ups / Open Questions
- Wire the validated payload back to Ruby for geometry creation once the Insert action is specified.
- Decide on default parameter values or persisted preferences so the form can seed sensible starting values.
- Consider extending unit alias coverage (e.g., Unicode fraction glyphs) and handling pure foot display should engineering/decimal-foot models need different formatting.


------
https://chatgpt.com/codex/tasks/task_e_68fc2b3181388333abe56225c7f27e32