### PR TITLE
[ui] Wire Ruby↔JS message passing for Insert parameters

### DIFF
--- a/aicabinets/ui/dialogs/insert_base_cabinet.css
+++ b/aicabinets/ui/dialogs/insert_base_cabinet.css
@@ -61,6 +61,30 @@ body {
   color: rgba(0, 0, 0, 0.75);
 }
 
+.form__banner {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+}
+
+.form__banner[hidden] {
+  display: none;
+}
+
+.form__banner--error {
+  border-color: rgba(211, 47, 47, 0.35);
+  background-color: rgba(211, 47, 47, 0.1);
+  color: rgba(97, 26, 21, 0.95);
+}
+
+.form__banner--success {
+  border-color: rgba(56, 142, 60, 0.35);
+  background-color: rgba(56, 142, 60, 0.12);
+  color: rgba(27, 94, 32, 0.95);
+}
+
 .form__section {
   display: flex;
   flex-direction: column;

--- a/aicabinets/ui/dialogs/insert_base_cabinet.html
+++ b/aicabinets/ui/dialogs/insert_base_cabinet.html
@@ -21,6 +21,7 @@
           <p class="form__notice" data-role="units-note">
             Values without a suffix use the model’s display unit. Examples: 600, 450mm, 2' 3-1/2", 24 in.
           </p>
+          <div class="form__banner" data-role="form-banner" hidden aria-live="polite"></div>
 
           <section class="form__section">
             <h2 class="form__section-title">Dimensions</h2>
@@ -117,6 +118,7 @@
                   <option value="doors_double">Doors — double</option>
                 </select>
                 <p class="field-help">Choose the door configuration for the cabinet front.</p>
+                <p class="field-error" data-error-for="front" aria-live="polite"></p>
               </div>
 
               <div class="form-field" data-field="shelves">
@@ -147,6 +149,7 @@
               <p class="field-help">
                 Add vertical partitions to divide the interior. Choose even spacing or provide explicit positions.
               </p>
+              <p class="field-error" data-error-for="partitions_mode" aria-live="polite"></p>
             </div>
 
             <div class="form-field is-hidden" data-field="partitions_count" data-partitions-control="even">


### PR DESCRIPTION
## Summary
- bridge the Insert dialog to Ruby via the `aicb_submit_params` HtmlDialog callback, parse the JSON payload defensively in Ruby, and answer with `{ok:true|false}` acknowledgements
- update the Insert form controller to build a canonical mm payload, disable **Insert** while awaiting the ack, and surface banner/inline feedback (success stays in-dialog with an auto-dismiss toast)
- add HTML/CSS affordances for the status banner and new error slots so ack feedback appears without blocking future geometry work

Closes #33

## Acceptance Criteria
- [ ] JS posts the validated payload once per click and keeps **Insert** disabled until the Ruby ack arrives (verify in SketchUp; headless dev environment cannot capture a GIF)
- [ ] Ruby parses and type-checks the mm payload, returning `{ok:true}` when valid (observe the Ruby console during manual testing)
- [ ] Malformed/invalid payloads return `{ok:false, …}` and trigger inline/banner errors without freezing the dialog (exercise by sending negative/unsorted inputs manually)
- [ ] Repeated clicks while awaiting the ack are ignored because the button is disabled (confirm interactively)
- [ ] Closing the dialog immediately after submit avoids console exceptions thanks to the guarded `execute_script` call (smoke test in SketchUp)
- [ ] Each dialog instance registers the callback once (check console logs during manual verification)

## Follow-ups / Open questions
- Consider persisting the last validated payload or emitting an event once geometry insertion work begins.
- Revisit the ack error taxonomy once more cabinet types exist.

## Rollback Plan
- Revert the JS/HTML/CSS submit wiring along with `insert_base_cabinet_dialog.rb` to restore the previous no-op Insert action.


------
https://chatgpt.com/codex/tasks/task_e_68fc35bfdb6883338398b1c703ea362e