### PR TITLE
[generator] Apply category tags + default materials to carcass parts

### DIFF
--- a/aicabinets/ops/materials.rb
+++ b/aicabinets/ops/materials.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'sketchup.rb'
+
+module AICabinets
+  module Ops
+    module Materials
+      module_function
+
+      DEFAULT_CARCASS_MATERIAL_NAME = if defined?(AICabinets::DEFAULT_CABINET_MATERIAL)
+                                         AICabinets::DEFAULT_CABINET_MATERIAL
+                                       else
+                                         'Birch Plywood'
+                                       end
+
+      # Resolves the default carcass material for the given model. Returns nil
+      # when the configured material is not present, allowing callers to fall
+      # back to SketchUp's default appearance without raising errors.
+      #
+      # @param model [Sketchup::Model]
+      # @return [Sketchup::Material, nil]
+      def default_carcass(model)
+        raise ArgumentError, 'model must be a Sketchup::Model' unless model.is_a?(Sketchup::Model)
+
+        name = DEFAULT_CARCASS_MATERIAL_NAME
+        return nil if name.to_s.empty?
+
+        model.materials[name]
+      end
+    end
+  end
+end

--- a/aicabinets/ops/tags.rb
+++ b/aicabinets/ops/tags.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'sketchup.rb'
+
+module AICabinets
+  module Ops
+    module Tags
+      module_function
+
+      # Ensures a tag exists on the model and returns it. SketchUp's Ruby API
+      # exposes tags through Model#layers.
+      #
+      # @param model [Sketchup::Model]
+      # @param name [String]
+      # @return [Sketchup::Layer]
+      def ensure_tag(model, name)
+        raise ArgumentError, 'model must be a Sketchup::Model' unless model.is_a?(Sketchup::Model)
+        raise ArgumentError, 'name must be provided' if name.to_s.empty?
+
+        layers = model.layers
+        layers[name] || layers.add(name)
+      end
+
+      # Assigns a tag to an entity, creating the tag if necessary.
+      #
+      # @param entity [Sketchup::Entity]
+      # @param name [String]
+      # @return [Sketchup::Layer]
+      def assign!(entity, name)
+        raise ArgumentError, 'entity must be a Sketchup::Entity' unless entity.is_a?(Sketchup::Entity)
+
+        layer = ensure_tag(entity.model, name)
+        entity.layer = layer if entity.respond_to?(:layer=)
+        layer
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- introduce `AICabinets::Ops::Tags` and `AICabinets::Ops::Materials` so tag lookup/creation and default carcass material resolution stay centralized and reusable
- tag each carcass part container and apply the resolved default material during generation, including heuristics to switch between `AICabinets/Top` and `AICabinets/Stretchers`
- track created entities individually for cleanup while keeping tagging/material assignment on the container level so raw geometry remains on Untagged

Closes #36

## Acceptance Criteria
- [ ] Clean model → build base carcass → tags (`AICabinets/Sides`, `AICabinets/Back`, `AICabinets/Bottom`, and `AICabinets/Top`/`Stretchers`) are created once *(manual SketchUp verification pending)*
- [ ] Created carcass containers use category tags; faces/edges remain on Untagged *(manual SketchUp verification pending)*
- [ ] Rebuild with existing tags → tags are reused without duplication *(manual SketchUp verification pending)*
- [ ] Default carcass material present → applied without console errors *(manual SketchUp verification pending)*
- [ ] Default carcass material absent → build succeeds with SketchUp default material *(manual SketchUp verification pending)*
- [ ] Carcass with stretchers uses `AICabinets/Stretchers` tag *(manual SketchUp verification pending)*

## Follow-ups / Open Questions
- Should the default carcass material be auto-created when missing, or should we keep the current tolerate-missing behavior?


------
https://chatgpt.com/codex/tasks/task_e_68fd26b4c5c08333b6c44cc64a0a256c