### PR TITLE
[core] User overrides for last‑used values (merge + atomic save)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ To verify Ruby syntax locally, run:
 ruby -c aicabinets.rb && find aicabinets -type f -name '*.rb' -print0 | xargs -0 -n1 ruby -c
 ```
 
+To print the effective defaults (shipped JSON merged with user overrides), run:
+
+```sh
+ruby -I. script/print_effective_defaults.rb
+```
+
+Reset persisted overrides during manual testing with:
+
+```sh
+ruby -I. script/reset_overrides.rb
+```
+
 To package the extension for manual installation, run:
 
 ```sh

--- a/aicabinets/defaults.rb
+++ b/aicabinets/defaults.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'fileutils'
 
 module AICabinets
   module Defaults
     module_function
 
     DATA_DIR = File.expand_path('data', __dir__)
+    USER_DIR = File.expand_path('user', __dir__)
     DEFAULTS_PATH = File.join(DATA_DIR, 'defaults.json')
+    OVERRIDES_PATH = File.join(USER_DIR, 'overrides.json')
+    OVERRIDES_TEMP_PATH = "#{OVERRIDES_PATH}.tmp"
     DEFAULT_VERSION = 1
+    NORMALIZATION_PRECISION = 3 # store mm values with 0.001 mm precision
 
     FRONT_OPTIONS = %w[empty doors_left doors_right doors_double].freeze
     PARTITION_MODES = %w[none even positions].freeze
@@ -46,6 +51,42 @@ module AICabinets
       deep_dup(FALLBACK_MM)
     end
 
+    def load_effective_mm
+      defaults = load_mm
+      overrides = read_overrides_mm
+
+      return defaults if overrides.empty?
+
+      merge_defaults(defaults, overrides)
+    rescue StandardError => error
+      warn("AI Cabinets: effective defaults load failed (#{error.message}); using shipped defaults.")
+      defaults
+    end
+
+    def save_overrides_mm(params_mm)
+      payload = build_overrides_payload(params_mm)
+      return false if payload.empty?
+
+      ensure_user_dir!
+
+      json = JSON.pretty_generate(payload)
+
+      File.open(OVERRIDES_TEMP_PATH, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+        file.write(json)
+        file.flush
+        file.fsync if file.respond_to?(:fsync)
+      end
+
+      File.delete(OVERRIDES_PATH) if File.exist?(OVERRIDES_PATH)
+      File.rename(OVERRIDES_TEMP_PATH, OVERRIDES_PATH)
+
+      true
+    rescue StandardError => error
+      warn("AI Cabinets: overrides save failed (#{error.message}).")
+      File.delete(OVERRIDES_TEMP_PATH) if File.exist?(OVERRIDES_TEMP_PATH)
+      false
+    end
+
     def read_defaults_file(path)
       return nil unless path
 
@@ -64,6 +105,201 @@ module AICabinets
       nil
     end
     private_class_method :read_defaults_file
+
+    def read_overrides_mm
+      return {} unless File.file?(OVERRIDES_PATH)
+
+      content = File.read(OVERRIDES_PATH, mode: 'r:BOM|UTF-8')
+      raw = JSON.parse(content)
+      sanitize_overrides(raw)
+    rescue JSON::ParserError => error
+      warn("AI Cabinets: overrides JSON parse error (#{error.message}); ignoring overrides.")
+      {}
+    rescue StandardError => error
+      warn("AI Cabinets: overrides file read error (#{error.message}); ignoring overrides.")
+      {}
+    end
+    private_class_method :read_overrides_mm
+
+    def sanitize_overrides(raw)
+      container = overrides_container(raw)
+      return {} unless container
+
+      sanitize_overrides_body(container)
+    end
+    private_class_method :sanitize_overrides
+
+    def overrides_container(raw)
+      unless raw.is_a?(Hash)
+        warn('AI Cabinets: overrides root must be an object; ignoring overrides.')
+        return nil
+      end
+
+      cabinet_base = raw.key?('cabinet_base') ? raw['cabinet_base'] : raw[:cabinet_base]
+
+      if cabinet_base
+        unless cabinet_base.is_a?(Hash)
+          warn('AI Cabinets: overrides cabinet_base must be an object; ignoring overrides.')
+          return nil
+        end
+
+        warn_unknown_keys_once(raw, ['cabinet_base'], 'overrides root')
+        cabinet_base
+      else
+        warn_unknown_keys_once(raw, RECOGNIZED_KEYS, 'overrides root')
+        raw
+      end
+    end
+    private_class_method :overrides_container
+
+    def sanitize_overrides_body(raw)
+      warn_unknown_keys_once(raw, RECOGNIZED_KEYS, 'overrides')
+
+      sanitized = {}
+
+      RECOGNIZED_KEYS.each do |key|
+        next unless raw.key?(key) || raw.key?(key.to_sym)
+
+        value = raw[key] || raw[key.to_sym]
+
+        case key
+        when 'partitions'
+          partitions = sanitize_overrides_partitions(value)
+          sanitized[:partitions] = partitions if partitions && !partitions.empty?
+        when 'front'
+          front = sanitize_override_front(value)
+          sanitized[:front] = front if front
+        when 'shelves'
+          shelves = sanitize_override_integer('overrides.shelves', value, min: 0, max: MAX_PARTITION_COUNT)
+          sanitized[:shelves] = shelves if shelves
+        else
+          numeric = sanitize_override_numeric("overrides.#{key}", value)
+          sanitized[key.to_sym] = numeric unless numeric.nil?
+        end
+      end
+
+      sanitized
+    end
+    private_class_method :sanitize_overrides_body
+
+    def sanitize_overrides_partitions(raw)
+      unless raw.is_a?(Hash)
+        warn('AI Cabinets: overrides.partitions must be an object; ignoring override.')
+        return nil
+      end
+
+      warn_unknown_keys_once(raw, RECOGNIZED_PARTITION_KEYS, 'overrides.partitions')
+
+      sanitized = {}
+
+      RECOGNIZED_PARTITION_KEYS.each do |key|
+        next unless raw.key?(key) || raw.key?(key.to_sym)
+
+        value = raw[key] || raw[key.to_sym]
+
+        case key
+        when 'mode'
+          mode = sanitize_override_enum('overrides.partitions.mode', value, PARTITION_MODES)
+          sanitized[:mode] = mode if mode
+        when 'count'
+          count = sanitize_override_integer('overrides.partitions.count', value, min: 0, max: MAX_PARTITION_COUNT)
+          sanitized[:count] = count if count
+        when 'positions_mm'
+          positions = sanitize_override_positions(value)
+          sanitized[:positions_mm] = positions if positions
+        when 'panel_thickness_mm'
+          if value.nil?
+            sanitized[:panel_thickness_mm] = nil
+          else
+            numeric = sanitize_override_numeric('overrides.partitions.panel_thickness_mm', value)
+            sanitized[:panel_thickness_mm] = numeric unless numeric.nil?
+          end
+        end
+      end
+
+      sanitized
+    end
+    private_class_method :sanitize_overrides_partitions
+
+    def sanitize_override_positions(value)
+      unless value.is_a?(Array)
+        warn('AI Cabinets: overrides.partitions.positions_mm must be an array; ignoring override.')
+        return nil
+      end
+
+      result = []
+      value.each_with_index do |element, index|
+        numeric = sanitize_override_numeric("overrides.partitions.positions_mm[#{index}]", element)
+        return nil unless numeric
+
+        if numeric.negative?
+          warn("AI Cabinets: overrides.partitions.positions_mm[#{index}] cannot be negative; ignoring override.")
+          return nil
+        end
+
+        result << numeric
+      end
+
+      return nil if result.empty?
+
+      result
+    end
+    private_class_method :sanitize_override_positions
+
+    def sanitize_override_numeric(label, value)
+      numeric = parse_numeric(value)
+      unless numeric
+        warn("AI Cabinets: #{label} must be a non-negative number; ignoring override.")
+        return nil
+      end
+
+      if numeric.negative?
+        warn("AI Cabinets: #{label} cannot be negative; ignoring override.")
+        return nil
+      end
+
+      numeric
+    end
+    private_class_method :sanitize_override_numeric
+
+    def sanitize_override_enum(label, value, allowed)
+      if value.is_a?(String)
+        normalized = value.strip
+        return normalized if allowed.include?(normalized)
+      end
+
+      warn("AI Cabinets: #{label} must be one of #{allowed.join(', ')}; ignoring override.")
+      nil
+    end
+    private_class_method :sanitize_override_enum
+
+    def sanitize_override_front(value)
+      sanitize_override_enum('overrides.front', value, FRONT_OPTIONS)
+    end
+    private_class_method :sanitize_override_front
+
+    def sanitize_override_integer(label, value, min:, max: nil)
+      numeric = parse_numeric(value)
+      unless numeric
+        warn("AI Cabinets: #{label} must be a non-negative integer; ignoring override.")
+        return nil
+      end
+
+      integer = numeric.round
+      if integer < min || (max && integer > max)
+        warn("AI Cabinets: #{label} out of range; ignoring override.")
+        return nil
+      end
+
+      integer
+    end
+    private_class_method :sanitize_override_integer
+
+    def warn_unknown_keys_once(raw, known_keys, label)
+      unknown = raw.each_key.reject { |key| known_keys.include?(key.to_s) }
+      warn("AI Cabinets: ignoring unknown #{label} key(s): #{unknown.join(', ')}.") if unknown.any?
+    end
+    private_class_method :warn_unknown_keys_once
 
     def sanitize_defaults(raw)
       return deep_dup(FALLBACK_MM) if raw.nil?
@@ -267,6 +503,101 @@ module AICabinets
       end
     end
     private_class_method :warn_unknown_keys
+
+    def merge_defaults(defaults, overrides)
+      result = deep_dup(defaults)
+
+      overrides.each do |key, value|
+        next unless FALLBACK_MM.key?(key)
+
+        result[key] =
+          if key == :partitions
+            merge_partitions(result[key], value)
+          else
+            value
+          end
+      end
+
+      result
+    end
+    private_class_method :merge_defaults
+
+    def merge_partitions(defaults, overrides)
+      base = defaults.is_a?(Hash) ? deep_dup(defaults) : deep_dup(PARTITIONS_FALLBACK)
+      return base unless overrides.is_a?(Hash)
+
+      overrides.each do |key, value|
+        next unless RECOGNIZED_PARTITION_KEYS.include?(key.to_s)
+
+        base[key] =
+          if key == :positions_mm && value.is_a?(Array)
+            value.map { |element| element.to_f }
+          else
+            value
+          end
+      end
+
+      base
+    end
+    private_class_method :merge_partitions
+
+    def build_overrides_payload(params_mm)
+      return {} unless params_mm.is_a?(Hash)
+
+      payload = {}
+      FALLBACK_MM.each_key do |key|
+        value = params_mm[key]
+        value = params_mm[key.to_s] if value.nil? && params_mm.key?(key.to_s)
+
+        payload[key.to_s] =
+          case key
+          when :partitions
+            build_overrides_partitions(value)
+          when :front
+            value.to_s
+          when :shelves
+            value.to_i
+          else
+            normalize_length_mm(value)
+          end
+      end
+
+      { 'cabinet_base' => payload }
+    end
+    private_class_method :build_overrides_payload
+
+    def build_overrides_partitions(value)
+      raw = value.is_a?(Hash) ? value : {}
+
+      PARTITIONS_FALLBACK.each_with_object({}) do |(key, _), result|
+        result[key.to_s] =
+          case key
+          when :mode
+            raw[key].to_s
+          when :count
+            raw[key].to_i
+          when :positions_mm
+            array = raw[key].is_a?(Array) ? raw[key] : []
+            array.map { |element| normalize_length_mm(element) }.compact
+          when :panel_thickness_mm
+            element = raw[key]
+            element.nil? ? nil : normalize_length_mm(element)
+          end
+      end
+    end
+    private_class_method :build_overrides_partitions
+
+    def normalize_length_mm(value)
+      return nil if value.nil?
+
+      value.to_f.round(NORMALIZATION_PRECISION)
+    end
+    private_class_method :normalize_length_mm
+
+    def ensure_user_dir!
+      FileUtils.mkdir_p(USER_DIR)
+    end
+    private_class_method :ensure_user_dir!
 
     def canonicalize(sanitized)
       result = {}

--- a/script/print_effective_defaults.rb
+++ b/script/print_effective_defaults.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+
+require 'json'
+require 'aicabinets/defaults'
+
+effective = AICabinets::Defaults.load_effective_mm
+
+puts(JSON.pretty_generate(effective))

--- a/script/reset_overrides.rb
+++ b/script/reset_overrides.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+
+require 'aicabinets/defaults'
+
+path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+
+default_message = "AI Cabinets: overrides file not found; nothing to reset."
+
+if File.exist?(path)
+  File.delete(path)
+  puts("AI Cabinets: deleted overrides file at #{path}.")
+else
+  puts(default_message)
+end

--- a/test/test_overrides.rb
+++ b/test/test_overrides.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+
+require 'aicabinets/defaults'
+
+class OverridesTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir('aicabinets-overrides-test-')
+    @original_user_dir = AICabinets::Defaults.const_get(:USER_DIR)
+    @original_overrides_path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+    @original_temp_path = AICabinets::Defaults.const_get(:OVERRIDES_TEMP_PATH)
+    override_overrides_paths(@tmpdir)
+  end
+
+  def teardown
+    override_overrides_paths(@original_user_dir, @original_overrides_path, @original_temp_path)
+    FileUtils.remove_entry(@tmpdir) if @tmpdir && Dir.exist?(@tmpdir)
+  end
+
+  def test_load_effective_mm_without_overrides_matches_defaults
+    defaults = AICabinets::Defaults.load_mm
+    effective = AICabinets::Defaults.load_effective_mm
+
+    assert_equal(defaults, effective)
+    assert_equal(defaults.keys, effective.keys)
+  end
+
+  def test_save_overrides_mm_writes_atomic_file
+    params = AICabinets::Defaults.load_mm
+    params[:width_mm] = 543.21098
+    params[:partitions] = {
+      mode: 'positions',
+      count: 2,
+      positions_mm: [100.0, 250.1234],
+      panel_thickness_mm: nil
+    }
+
+    rename_calls = []
+    singleton = class << File; self; end
+    singleton.alias_method :__original_rename, :rename
+    singleton.define_method(:rename) do |src, dest|
+      rename_calls << [src, dest]
+      __original_rename(src, dest)
+    end
+
+    begin
+      result = AICabinets::Defaults.save_overrides_mm(params)
+      assert(result)
+    ensure
+      singleton.remove_method(:rename)
+      singleton.alias_method :rename, :__original_rename
+      singleton.remove_method(:__original_rename)
+    end
+
+    overrides_path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+    temp_path = AICabinets::Defaults.const_get(:OVERRIDES_TEMP_PATH)
+
+    assert(File.exist?(overrides_path))
+    refute(File.exist?(temp_path))
+
+    assert_equal([[temp_path, overrides_path]], rename_calls)
+    assert_equal(File.dirname(overrides_path), File.dirname(rename_calls.first.first))
+
+    data = JSON.parse(File.read(overrides_path))
+    cabinet_base = data.fetch('cabinet_base')
+
+    expected_keys = %w[
+      width_mm
+      depth_mm
+      height_mm
+      panel_thickness_mm
+      toe_kick_height_mm
+      toe_kick_depth_mm
+      front
+      shelves
+      partitions
+    ]
+
+    assert_equal(expected_keys, cabinet_base.keys)
+    assert_in_delta(543.211, cabinet_base['width_mm'], 0.001)
+
+    partitions = cabinet_base.fetch('partitions')
+    assert_equal(%w[mode count positions_mm panel_thickness_mm], partitions.keys)
+    assert_equal('positions', partitions['mode'])
+    assert_equal(2, partitions['count'])
+    assert_equal([100.0, 250.123], partitions['positions_mm'])
+    assert_nil(partitions['panel_thickness_mm'])
+  end
+
+  def test_load_effective_mm_merges_overrides
+    overrides_path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+
+    File.write(
+      overrides_path,
+      JSON.pretty_generate(
+        'cabinet_base' => {
+          'width_mm' => 750,
+          'shelves' => 4,
+          'partitions' => {
+            'mode' => 'positions',
+            'count' => 2,
+            'positions_mm' => [150, 300]
+          }
+        }
+      )
+    )
+
+    effective = AICabinets::Defaults.load_effective_mm
+
+    assert_equal(750.0, effective[:width_mm])
+    assert_equal(4, effective[:shelves])
+
+    partitions = effective[:partitions]
+    assert_equal('positions', partitions[:mode])
+    assert_equal(2, partitions[:count])
+    assert_equal([150.0, 300.0], partitions[:positions_mm])
+    assert_nil(partitions[:panel_thickness_mm])
+    assert_equal(600.0, effective[:depth_mm])
+  end
+
+  def test_unknown_keys_warn_once_and_are_ignored
+    overrides_path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+
+    File.write(
+      overrides_path,
+      JSON.pretty_generate(
+        'cabinet_base' => {
+          'width_mm' => 700,
+          'mystery' => true,
+          'partitions' => {
+            'extra' => 10,
+            'mode' => 'none'
+          }
+        },
+        'unexpected' => 1
+      )
+    )
+
+    _, err = capture_io do
+      effective = AICabinets::Defaults.load_effective_mm
+      assert_equal(700.0, effective[:width_mm])
+      assert_equal('none', effective[:partitions][:mode])
+      refute(effective[:partitions].key?(:extra))
+    end
+
+    assert_includes(err, 'ignoring unknown overrides root key(s)')
+    assert_includes(err, 'ignoring unknown overrides key(s)')
+    assert_includes(err, 'ignoring unknown overrides.partitions key(s)')
+  end
+
+  def test_corrupt_overrides_are_ignored
+    overrides_path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+    File.write(overrides_path, '{ invalid json')
+
+    _, err = capture_io do
+      effective = AICabinets::Defaults.load_effective_mm
+      assert_equal(600.0, effective[:width_mm])
+    end
+
+    assert_includes(err, 'overrides JSON parse error')
+
+    File.write(overrides_path, JSON.pretty_generate('cabinet_base' => 'bad'))
+
+    _, err = capture_io do
+      effective = AICabinets::Defaults.load_effective_mm
+      assert_equal(600.0, effective[:width_mm])
+    end
+
+    assert_includes(err, 'overrides cabinet_base must be an object')
+  end
+
+  def test_load_effective_mm_is_deterministic
+    overrides_path = AICabinets::Defaults.const_get(:OVERRIDES_PATH)
+
+    File.write(
+      overrides_path,
+      JSON.pretty_generate('cabinet_base' => { 'depth_mm' => 575.5 })
+    )
+
+    first = AICabinets::Defaults.load_effective_mm
+    second = AICabinets::Defaults.load_effective_mm
+
+    assert_equal(first, second)
+    assert_equal(first.keys, second.keys)
+  end
+
+  private
+
+  def override_overrides_paths(user_dir, overrides_path = nil, temp_path = nil)
+    overrides_path ||= File.join(user_dir, 'overrides.json')
+    temp_path ||= "#{overrides_path}.tmp"
+
+    replace_const(:USER_DIR, user_dir)
+    replace_const(:OVERRIDES_PATH, overrides_path)
+    replace_const(:OVERRIDES_TEMP_PATH, temp_path)
+  end
+
+  def replace_const(name, value)
+    AICabinets::Defaults.send(:remove_const, name)
+    AICabinets::Defaults.const_set(name, value)
+  end
+end


### PR DESCRIPTION
## Summary
- expose `AICabinets::Defaults.load_effective_mm` to merge sanitized overrides with the shipped mm defaults while ignoring unknown keys and logging recoverable errors; normalization clamps stored lengths to 0.001 mm and all paths continue to derive from `__dir__`.
- add `AICabinets::Defaults.save_overrides_mm`, persisting recognized fields only and committing via temp-file-then-rename in the same directory to keep the write atomic on all supported platforms.
- provide helper scripts for printing the merged defaults and clearing overrides, plus focused tests that cover merge policy, logging, determinism, and atomic rename behavior.

Closes #52

## Testing
- ruby -c aicabinets.rb && find aicabinets -type f -name '*.rb' -print0 | xargs -0 -n1 ruby -c
- ruby -I. test/test_defaults.rb
- ruby -I. test/test_overrides.rb

## Acceptance Criteria
- [x] First run without overrides matches `load_mm` (`test_load_effective_mm_without_overrides_matches_defaults`).
- [x] `save_overrides_mm` writes only recognized keys via temp+rename (`test_save_overrides_mm_writes_atomic_file`).
- [x] Overrides deep-merge on subsequent loads (`test_load_effective_mm_merges_overrides`).
- [x] Unknown keys are ignored with a single warning (`test_unknown_keys_warn_once_and_are_ignored`).
- [x] Corrupt overrides fall back to defaults with a warning (`test_corrupt_overrides_are_ignored`).
- [x] Repeated loads remain deterministic (`test_load_effective_mm_is_deterministic`).
- [x] Atomic write stays within the target directory (`test_save_overrides_mm_writes_atomic_file`).

## Follow-ups / Open Questions
- Confirm that storing overrides at 0.001 mm precision aligns with downstream UI expectations; adjust precision if a different tolerance is desired.
- Consider migrating overrides to an OS-specific user data directory in a future packaging task if SketchUp’s plugin folder is not writable for all users.


------
https://chatgpt.com/codex/tasks/task_e_68fe97a4f9e08333ae28c6c0786388a7