### PR TITLE
[ci] Package RBZ on tag and upload artifact (optional Release attach)

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -1,0 +1,56 @@
+name: Package RBZ
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  package:
+    name: Package extension
+    runs-on: ubuntu-latest
+    env:
+      PUBLISH_RELEASE: ${{ vars.AICABINETS_PUBLISH_RELEASE || 'false' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Read extension version
+        id: read_version
+        run: |
+          version=$(ruby -e "require_relative 'aicabinets/version'; print AICabinets::VERSION")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag matches AICabinets::VERSION
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          code_version="${{ steps.read_version.outputs.version }}"
+          if [ "${tag_version}" != "${code_version}" ]; then
+            echo "Tag ${tag_version} does not match AICabinets::VERSION ${code_version}" >&2
+            exit 1
+          fi
+
+      - name: Package RBZ
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version="${{ steps.read_version.outputs.version }}"
+          mkdir -p dist
+          zip -r "dist/aicabinets-${version}.rbz" aicabinets.rb aicabinets/
+
+      - name: Upload RBZ artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aicabinets-${{ steps.read_version.outputs.version }}.rbz
+          path: dist/aicabinets-${{ steps.read_version.outputs.version }}.rbz
+          if-no-files-found: error
+
+      - name: Publish GitHub Release
+        if: env.PUBLISH_RELEASE == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/aicabinets-${{ steps.read_version.outputs.version }}.rbz

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ To package the extension for manual installation, run:
 zip -r aicabinets-$(ruby -e "load 'aicabinets/version.rb'; puts AICabinets::VERSION").rbz aicabinets.rb aicabinets/
 ```
 
+When a tag matching `v*` is pushed, the **Package RBZ** workflow zips `aicabinets.rb` and `aicabinets/` into `dist/aicabinets-<VERSION>.rbz`, uploads it as a workflow artifact, and can optionally publish the file on the tag’s GitHub Release.
+
 ## Settings & Defaults (mm)
 
 AI Cabinets ships read-only defaults at `aicabinets/data/defaults.json` within the installed extension folder. The extension creates `aicabinets/user/overrides.json` after your first successful Insert or Edit action to persist user-chosen values. Both files live alongside `aicabinets.rb` in the extension’s support directory.


### PR DESCRIPTION
## Summary
- add a tag-triggered Package RBZ workflow that checks out the repo, installs Ruby 3.2, and aborts if the pushed tag (v*) does not match `AICabinets::VERSION`
- zip only `aicabinets.rb` and the `aicabinets/` folder into `dist/aicabinets-<VERSION>.rbz`, then upload the archive as a workflow artifact named after the version
- gate optional GitHub Release publishing behind the `AICABINETS_PUBLISH_RELEASE` repository variable so maintainers can opt in without editing the workflow

Closes #58

## Acceptance Criteria
- [x] Tag trigger → `on.push.tags: ['v*']` runs on ubuntu-latest with packaging guarded by `startsWith(github.ref, 'refs/tags/')`
- [x] Version consistency → `Ensure tag matches AICabinets::VERSION` step fails when the tag and code version differ
- [x] Packaging output → `Package RBZ` zips only `aicabinets.rb` and `aicabinets/` into `dist/aicabinets-<VERSION>.rbz`
- [x] Artifact upload → `Upload RBZ artifact` exposes the generated archive via `actions/upload-artifact@v4`
- [x] Optional Release → `Publish GitHub Release` attaches the RBZ when `AICABINETS_PUBLISH_RELEASE` is set to `true`
- [x] Installability → resulting RBZ mirrors the README command that installs in SketchUp 2026

## Follow-ups / Open Questions
- Decide on the default `AICABINETS_PUBLISH_RELEASE` repository variable value (currently defaults to `false`) and whether artifacts should be retained beyond the GitHub default.

## Rollback Plan
- Delete `.github/workflows/ci-package.yml` to disable the packaging workflow.


------
https://chatgpt.com/codex/tasks/task_e_68fec140e5e48333ab6c37ba515e6f5d