### PR TITLE
[ci] Add docs validation (markdownlint, cspell, linkinator) and update AGENTS.md

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "language": "en",
+  "ignorePaths": [
+    "dist/**",
+    "node_modules/**",
+    ".git/**"
+  ],
+  "words": [
+    "AICabinets",
+    "HtmlDialog",
+    "Linkinator",
+    "Markdownlint",
+    "frameless",
+    "RBZ",
+    "RuboCop",
+    "SketchUp",
+    "TestUp",
+    "postconditions",
+    "undoable"
+  ]
+}

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,0 +1,56 @@
+name: Docs Validate
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.md'
+      - '.github/workflows/docs-validate.yml'
+      - '.markdownlint.jsonc'
+      - '.cspell.json'
+      - '.linkinator.config.json'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/docs-validate.yml'
+      - '.markdownlint.jsonc'
+      - '.cspell.json'
+      - '.linkinator.config.json'
+
+jobs:
+  docs:
+    name: Documentation validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run markdownlint
+        run: >-
+          npx --yes markdownlint-cli@0.41.0
+          "**/*.md"
+          --config .markdownlint.jsonc
+          --ignore node_modules
+          --ignore dist
+
+      - name: Run cspell
+        run: >-
+          npx --yes cspell@8.14.2
+          "**/*.md"
+          --config .cspell.json
+          --no-progress
+          --no-summary
+
+      - name: Run linkinator
+        run: >-
+          npx --yes linkinator@6.0.0
+          "**/*.md"
+          --config ./.linkinator.config.json
+          --skip "https://help\\.sketchup\\.com/.*"
+          --skip "https://www\\.githubstatus\\.com/.*"

--- a/.linkinator.config.json
+++ b/.linkinator.config.json
@@ -1,0 +1,19 @@
+{
+  "recurse": true,
+  "markdown": true,
+  "timeout": 60000,
+  "retry": {
+    "count": 2,
+    "statusCodes": [
+      429,
+      500,
+      502,
+      503,
+      504
+    ]
+  },
+  "linksToSkip": [
+    "https://help\\.sketchup\\.com/.*",
+    "https://www\\.githubstatus\\.com/.*"
+  ]
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,6 @@
+{
+  // Enable default markdownlint rules but relax maximum line length to avoid churn.
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "default": true,
+  "MD013": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Use this section to standardize tone and content quality across issues, PRs, doc
 * Use third-person descriptive voice. The tone should be professional and informative. Use the present tense for descriptions.
 * Trim Unnecessary Details: If the documentation becomes too lengthy or includes information that’s not crucial for understanding a feature or API’s usage, trim it down. Developers typically read docs to decide how to use an API; focus on information that influences that decision or helps in using the API correctly. For example:
   * Omit internal algorithm details unless knowing them helps the user (e.g., mentioning that a method uses caching might explain why calling it repeatedly is cheap).
-  * Avoid repeating information that can be inferred. (If a parameter name is count and the <param> description just says “The count.”, that’s not helpful. Either expand on what “count” means in context or omit such a redundant comment.)
+  * Avoid repeating information that can be inferred. (If a parameter name is count and the parameter description just says “The count.”, that’s not helpful. Either expand on what “count” means in context or omit such a redundant comment.)
   * Ensure the length is appropriate: shorter for simple members, longer (but still focused) for complex ones. It’s better to be slightly succinct than to overwhelm with extraneous info.
 
 ### Terminology
@@ -257,3 +257,18 @@ Use this section to standardize tone and content quality across issues, PRs, doc
 * For behavior changes, include **Before/After** notes and link to the driving issue.
 * Keep screenshots minimal and current; annotate only where it clarifies behavior.
 * When describing measurements, state **units explicitly** and avoid mixing unit systems in a single example.
+
+## Local validation (docs & Ruby)
+
+Run these commands before sending a PR when you touch Markdown or Ruby files so CI matches local results:
+
+### Markdown changes
+
+* `npx --yes markdownlint-cli@0.41.0 "**/*.md" --config .markdownlint.jsonc --ignore node_modules --ignore dist`
+* `npx --yes cspell@8.14.2 "**/*.md" --config .cspell.json --no-progress --no-summary`
+* `npx --yes linkinator@6.0.0 "**/*.md" --config ./.linkinator.config.json --skip "https://help\\.sketchup\\.com/.*" --skip "https://www\\.githubstatus\\.com/.*"`
+
+### Ruby changes
+
+* `bundle exec rubocop --parallel --display-cop-names`
+  * If RuboCop is not yet installed locally, run `bundle install` first, or fallback to `gem install rubocop && rubocop --parallel --display-cop-names`.

--- a/tests/AI Cabinets/README.md
+++ b/tests/AI Cabinets/README.md
@@ -5,6 +5,7 @@ This folder contains the TestUp test suite for AI Cabinets. Add the folder to th
 suite will appear in the TestUp panel as **AI Cabinets**.
 
 ## Running
+
 1. Install the AI Cabinets extension and the TestUp 2 extension in SketchUp.
 2. In TestUp Preferences, add the absolute path to this folder.
 3. Open the TestUp window and run the suite or the individual test cases such as


### PR DESCRIPTION
## Summary
- add a Docs Validate workflow that only runs on Markdown changes and executes pinned `npx` invocations of markdownlint, cspell, and linkinator on the Ubuntu runner
- seed repo-level configs for markdownlint, cspell, and linkinator (including retry/timeout behavior and skips for flaky SketchUp and GitHub Status domains)
- document the matching local commands in AGENTS.md and fix existing Markdown lint warnings uncovered by the new checks

Closes #125

## Testing
- `npx --yes markdownlint-cli@0.41.0 "**/*.md" --config .markdownlint.jsonc --ignore node_modules --ignore dist`
- `npx --yes cspell@8.14.2 "**/*.md" --config .cspell.json --no-progress --no-summary`
- `npx --yes linkinator@6.0.0 "**/*.md" --config ./.linkinator.config.json --skip "https://help\\.sketchup\\.com/.*" --skip "https://www\\.githubstatus\\.com/.*"`

## Acceptance Criteria
- [x] Docs Validate workflow runs on PRs that touch Markdown by limiting the trigger paths
- [x] markdownlint failures will fail the job because the workflow runs markdownlint-cli with the repo config
- [x] cspell failures will fail the job because the workflow runs cspell with the seeded dictionary
- [x] linkinator failures will fail the job because the workflow runs linkinator with retries/timeouts and explicit skips for flaky SketchUp/GitHub Status domains
- [x] RuboCop guidance remains in existing CI and AGENTS.md now points to the local command to match it

## Follow-ups / Open Questions
- None.


------
https://chatgpt.com/codex/tasks/task_e_690220b13e44833389a6acb967b4c9be