### PR TITLE
[ui] Build `LayoutModel` (config → front-view rectangles)

### DIFF
--- a/aicabinets/layout/model.rb
+++ b/aicabinets/layout/model.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+module AICabinets
+  module Layout
+    module Model
+      EPS_MM = 1.0e-3
+
+      module_function
+
+      # Builds a hash describing the cabinet's front-view layout in millimeters.
+      #
+      # @param params_mm [Hash] Canonical cabinet parameters expressed in mm.
+      # @return [Hash] Structured layout model with outer bounds, bay rectangles,
+      #   optional fronts, and warnings when normalization is applied.
+      def build(params_mm)
+        params = params_mm.is_a?(Hash) ? params_mm : {}
+
+        outer_width_mm = dimension_mm(params[:width_mm])
+        outer_height_mm = dimension_mm(params[:height_mm])
+
+        bay_rects, normalization_warning = build_bays(params[:partitions], outer_width_mm, outer_height_mm)
+
+        {
+          outer: {
+            w_mm: outer_width_mm,
+            h_mm: outer_height_mm
+          },
+          bays: bay_rects,
+          fronts: [],
+          warnings: build_warnings(normalization_warning)
+        }
+      end
+
+      def build_warnings(normalization_warning)
+        warnings = []
+        warnings << normalization_warning if normalization_warning
+        warnings
+      end
+      private_class_method :build_warnings
+
+      def build_bays(partitions, outer_width_mm, outer_height_mm)
+        partitions_hash = partitions.is_a?(Hash) ? partitions : {}
+        bay_specs = Array(partitions_hash[:bays]).map { |bay| bay.is_a?(Hash) ? bay.dup : {} }
+        bay_count = bay_specs.length
+
+        return [[], nil] if bay_count.zero? || outer_width_mm <= 0.0
+
+        widths_mm = compute_initial_widths(partitions_hash, bay_specs, outer_width_mm)
+        widths_mm = adjust_widths_count(widths_mm, bay_count)
+        widths_mm = sanitize_widths(widths_mm)
+
+        widths_mm, warning = normalize_widths(widths_mm, outer_width_mm)
+
+        rectangles = []
+        cursor = 0.0
+        widths_mm.each_with_index do |width_mm, index|
+          rectangles << {
+            id: bay_identifier(bay_specs[index], index),
+            role: 'bay',
+            x_mm: cursor,
+            y_mm: 0.0,
+            w_mm: width_mm,
+            h_mm: outer_height_mm
+          }
+          cursor += width_mm
+        end
+
+        [rectangles, warning]
+      end
+      private_class_method :build_bays
+
+      def compute_initial_widths(partitions, bay_specs, outer_width_mm)
+        hints = widths_from_hints(bay_specs)
+        return hints if hints
+
+        mode = partitions[:mode].to_s.strip.downcase
+        bay_count = bay_specs.length
+
+        return widths_from_positions(partitions, bay_count, outer_width_mm) if mode == 'positions'
+
+        even_widths(bay_count, outer_width_mm)
+      end
+      private_class_method :compute_initial_widths
+
+      def widths_from_hints(bay_specs)
+        hints = bay_specs.map do |bay|
+          layout = hash_or_nil(bay[:layout]) || hash_or_nil(bay['layout'])
+          width = layout && (layout[:width_mm] || layout['width_mm'])
+          width ? dimension_mm(width) : nil
+        end
+
+        return nil if hints.compact.empty?
+
+        hints.map { |value| value || 0.0 }
+      end
+      private_class_method :widths_from_hints
+
+      def widths_from_positions(partitions, bay_count, outer_width_mm)
+        positions = Array(partitions[:positions_mm])
+        numeric = positions.map { |value| dimension_mm(value) }.compact
+        sorted = numeric.sort
+        trimmed = sorted.first([bay_count - 1, 0].max)
+
+        boundaries = [0.0]
+        trimmed.each do |position|
+          clamped = clamp(position, 0.0, outer_width_mm)
+          next if (clamped - boundaries.last).abs <= EPS_MM
+
+          boundaries << clamped
+        end
+        boundaries << outer_width_mm unless (boundaries.last - outer_width_mm).abs <= EPS_MM
+
+        widths = []
+        boundaries.each_cons(2) do |left, right|
+          widths << [right - left, 0.0].max
+        end
+        widths
+      end
+      private_class_method :widths_from_positions
+
+      def even_widths(bay_count, outer_width_mm)
+        return [] if bay_count <= 0
+
+        width = bay_count.positive? ? outer_width_mm.to_f / bay_count : 0.0
+        Array.new(bay_count, width)
+      end
+      private_class_method :even_widths
+
+      def adjust_widths_count(widths, bay_count)
+        widths = Array(widths)
+        if widths.length > bay_count
+          widths.first(bay_count)
+        elsif widths.length < bay_count
+          widths + Array.new(bay_count - widths.length, 0.0)
+        else
+          widths
+        end
+      end
+      private_class_method :adjust_widths_count
+
+      def sanitize_widths(widths)
+        widths.map do |width|
+          value = width.to_f
+          value.negative? ? 0.0 : value
+        end
+      end
+      private_class_method :sanitize_widths
+
+      def normalize_widths(widths, outer_width_mm)
+        sum = widths.sum
+        difference = outer_width_mm - sum
+        return [widths, nil] if difference.abs <= EPS_MM
+
+        if sum <= EPS_MM
+          recalculated = even_widths(widths.length, outer_width_mm)
+          message = format('Normalized bay widths to sum to outer.w_mm (delta %.3f mm).', difference)
+          return [recalculated, message]
+        end
+
+        scale = outer_width_mm / sum
+        scaled = widths.map { |width| width * scale }
+        correction = outer_width_mm - scaled.sum
+        scaled[-1] = scaled[-1] + correction if scaled.any?
+
+        message = format('Normalized bay widths to sum to outer.w_mm (delta %.3f mm).', difference)
+        [scaled, message]
+      end
+      private_class_method :normalize_widths
+
+      def bay_identifier(bay_spec, index)
+        id = bay_spec[:id] || bay_spec['id']
+        return id unless id.nil?
+
+        index + 1
+      end
+      private_class_method :bay_identifier
+
+      def dimension_mm(value)
+        return 0.0 if value.nil?
+
+        if value.is_a?(Numeric)
+          value.to_f
+        else
+          Float(value)
+        end
+      rescue ArgumentError, TypeError
+        0.0
+      end
+      private_class_method :dimension_mm
+
+      def hash_or_nil(value)
+        value.is_a?(Hash) ? value : nil
+      end
+      private_class_method :hash_or_nil
+
+      def clamp(value, min_value, max_value)
+        [[value, max_value].min, min_value].max
+      end
+      private_class_method :clamp
+    end
+  end
+end

--- a/tests/AI Cabinets/TC_LayoutModel.rb
+++ b/tests/AI Cabinets/TC_LayoutModel.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'testup/testcase'
+
+require_relative 'suite_helper'
+
+Sketchup.require('aicabinets/layout/model')
+
+class TC_LayoutModel < TestUp::TestCase
+  def test_even_three_bays_equal_width
+    params = base_params.merge(
+      width_mm: 762.0,
+      height_mm: 762.0,
+      partitions: {
+        mode: 'even',
+        count: 2,
+        orientation: 'vertical',
+        bays: Array.new(3) { {} }
+      }
+    )
+
+    result = AICabinets::Layout::Model.build(params)
+
+    assert_equal(3, result[:bays].length)
+    assert_equal({ w_mm: 762.0, h_mm: 762.0 }, result[:outer])
+
+    widths = result[:bays].map { |bay| bay[:w_mm] }
+    AICabinetsTestHelper.assert_within_tolerance(self, 254.0, widths[0], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 254.0, widths[1], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 254.0, widths[2], 1.0e-6)
+
+    x_values = result[:bays].map { |bay| bay[:x_mm] }
+    AICabinetsTestHelper.assert_within_tolerance(self, 0.0, x_values[0], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 254.0, x_values[1], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 508.0, x_values[2], 1.0e-6)
+
+    sum_width = widths.sum
+    AICabinetsTestHelper.assert_within_tolerance(
+      self,
+      result[:outer][:w_mm],
+      sum_width,
+      AICabinets::Layout::Model::EPS_MM
+    )
+  end
+
+  def test_positions_mixed_widths
+    params = base_params.merge(
+      width_mm: 762.0,
+      height_mm: 700.0,
+      partitions: {
+        mode: 'positions',
+        positions_mm: [300.0, 500.0],
+        count: 2,
+        orientation: 'vertical',
+        bays: Array.new(3) { {} }
+      }
+    )
+
+    result = AICabinets::Layout::Model.build(params)
+
+    widths = result[:bays].map { |bay| bay[:w_mm] }
+    AICabinetsTestHelper.assert_within_tolerance(self, 300.0, widths[0], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 200.0, widths[1], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 262.0, widths[2], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(
+      self,
+      result[:outer][:w_mm],
+      widths.sum,
+      AICabinets::Layout::Model::EPS_MM
+    )
+
+    heights = result[:bays].map { |bay| bay[:h_mm] }
+    heights.each do |height|
+      AICabinetsTestHelper.assert_within_tolerance(self, 700.0, height, 1.0e-6)
+    end
+  end
+
+  def test_degenerate_zero_bays
+    params = base_params.merge(
+      width_mm: 600.0,
+      height_mm: 700.0,
+      partitions: {
+        mode: 'none',
+        count: 0,
+        orientation: 'vertical',
+        bays: []
+      }
+    )
+
+    result = AICabinets::Layout::Model.build(params)
+
+    assert_equal([], result[:bays])
+    assert_equal({ w_mm: 600.0, h_mm: 700.0 }, result[:outer])
+  end
+
+  def test_degenerate_single_bay_matches_outer
+    params = base_params.merge(
+      width_mm: 500.0,
+      height_mm: 640.0,
+      partitions: {
+        mode: 'none',
+        count: 0,
+        orientation: 'vertical',
+        bays: [{}]
+      }
+    )
+
+    result = AICabinets::Layout::Model.build(params)
+
+    assert_equal(1, result[:bays].length)
+    bay = result[:bays].first
+    AICabinetsTestHelper.assert_within_tolerance(self, 500.0, bay[:w_mm], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 640.0, bay[:h_mm], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 0.0, bay[:x_mm], 1.0e-6)
+    AICabinetsTestHelper.assert_within_tolerance(self, 0.0, bay[:y_mm], 1.0e-6)
+  end
+
+  def test_normalizes_when_width_sum_deviates
+    params = base_params.merge(
+      width_mm: 900.0,
+      height_mm: 700.0,
+      partitions: {
+        mode: 'even',
+        count: 2,
+        orientation: 'vertical',
+        bays: [
+          { layout: { width_mm: 250.0 } },
+          { layout: { width_mm: 250.0 } },
+          { layout: { width_mm: 250.0 } }
+        ]
+      }
+    )
+
+    result = AICabinets::Layout::Model.build(params)
+
+    widths = result[:bays].map { |bay| bay[:w_mm] }
+    AICabinetsTestHelper.assert_within_tolerance(
+      self,
+      900.0,
+      widths.sum,
+      AICabinets::Layout::Model::EPS_MM
+    )
+    refute_empty(result[:warnings])
+    assert(result[:warnings].first.include?('Normalized bay widths'), 'Expected normalization warning')
+  end
+
+  private
+
+  def base_params
+    {
+      width_mm: 0.0,
+      height_mm: 0.0,
+      partitions: {
+        mode: 'none',
+        count: 0,
+        orientation: 'vertical',
+        bays: []
+      }
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- add `AICabinets::Layout::Model.build` to translate canonical cabinet params into front-view layout hashes with `outer`, `bays`, `fronts`, and `warnings`
- compute bay widths from explicit hints or partition metadata, normalize sums within `EPS_MM = 1.0e-3 mm`, and emit warnings when adjustments are applied
- cover even, positioned, degenerate, and normalization flows with a new `TC_LayoutModel` TestUp case while keeping the builder pure Ruby with no SketchUp dependencies

Closes #200

## Testing
- `bundle exec rubocop --parallel --display-cop-names`
- `ruby -c aicabinets.rb && find aicabinets -type f -name '*.rb' -print0 | xargs -0 -n1 ruby -c`

## Acceptance Criteria
- [x] AC1 – Basic 3-bay layout (`TC_LayoutModel#test_even_three_bays_equal_width`)
- [x] AC2 – Mixed widths (`TC_LayoutModel#test_positions_mixed_widths`)
- [x] AC3 – Degenerate cases (`TC_LayoutModel#test_degenerate_zero_bays`, `#test_degenerate_single_bay_matches_outer`)
- [x] AC4 – Tolerance & validation (`TC_LayoutModel#test_normalizes_when_width_sum_deviates`)
- [ ] AC5 – Fronts (left for follow-up once front grouping params are finalized)
- [x] AC6 – Purity (builder uses only Ruby stdlib; exercised via pure TestUp case)
- [x] AC7 – Unit tests (`tests/AI Cabinets/TC_LayoutModel.rb`)

## Follow-ups / Open Questions
- document how grouped fronts should be surfaced in params once UX specifies the payload shape and roles
- confirm whether additional metadata (e.g., partition thickness, reveal offsets) should appear in the layout model for richer previews

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fed51df888333989d50e78a9b549f)