### PR TITLE
[docs/process] Mark lib/* read-only prototype; update AGENTS.md + PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+- _Concise explanation of what changed and why._
+
+## Testing
+- _Commands run or reasoning for why testing was not required._
+
+## Checklist
+- [ ] Acceptance criteria in the linked issue are met.
+- [ ] Changes respect project invariants (FLB carcass anchor, parameters stored on definitions, lengths handled in mm as needed).
+- [ ] Tests updated or added where behavior changed.
+- [ ] README or user docs updated if behavior is user-visible.
+- [ ] This PR does not change files under lib/* (unless this is an explicitly scoped migration/removal task).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ These rules apply across the codebase and issues.
 * Namespace all code under `AICabinets`.
 * Use a registrar (`aicabinets.rb`) and a support folder (`aicabinets/`).
 * Prefer `Sketchup.require` for load paths to remain compatible with packaged/signed extensions.
+* `lib/*` contains prototype/POC reference code kept for historical context. It is read-only for agents and will be removed once the extension reaches a superset of feature parity.
 
 ## Best‑Practice References (IDs you can cite in issues)
 
@@ -62,6 +63,7 @@ Use these short IDs in **Implementation Notes (Constraints & Practices)** to jus
 * **BP‑7:** Tag **by category**; create tags if missing; avoid dimension‑encoded names.
 * **BP‑8:** Use `Sketchup.require`, not `require_relative`, for extension‑friendly loading.
 * **BP‑9:** Accept and display lengths using model units; parse with `String#to_l`/`.mm` and format with `Sketchup.format_length`.
+* **BP‑10:** `lib/*` is a read-only prototype. Do not modify.
 
 ## Issue Types
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,5 @@
+# Prototype reference (read-only)
+
+- `lib/` contains prototype/POC reference implementations retained for historical context during the SketchUp extension MVP.
+- Agents must not edit files in this directory unless working on a maintainer-approved migration or removal task.
+- The directory will be removed once the extension reaches a superset of the prototype's feature parity.


### PR DESCRIPTION
## Summary
- Documented that `lib/*` remains a read-only prototype kept only for historical context during the SketchUp extension MVP and will be removed after feature parity.
- Added best-practice rule BP-10 and a PR checklist guardrail to block casual edits under `lib/`.
- Introduced `lib/README.md` to restate the directory’s purpose, edit policy, and removal plan.

## Acceptance Criteria
- [x] **AC1 — AGENTS.md (policy statement):** Added the read-only prototype policy under File Layout & Loading in `AGENTS.md`.
- [x] **AC2 — AGENTS.md (best-practice ID):** Registered best-practice **BP-10** with the explicit "`lib/*` is a read-only prototype" rule in `AGENTS.md`.
- [x] **AC3 — PR checklist:** Created `.github/pull_request_template.md` with the guardrail checkbox warning against editing `lib/*`.
- [x] **AC4 — `lib/README.md`:** Added a README containing the required three bullet points covering purpose, edit policy, and removal plan.
- [x] **AC5 — Scope guard:** Only touched documentation files; no other files in `lib/` were modified.
- [x] **AC6 — Hygiene:** Markdown-only changes; existing lint/tests remain unaffected.

## Open Questions
- None.

Closes #235

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161665b3ac8333bf75b9e2d2066769)