### PR TITLE
[params] Define face_frame schema & defaults

### DIFF
--- a/aicabinets/data/defaults.json
+++ b/aicabinets/data/defaults.json
@@ -19,6 +19,21 @@
       "bays": []
     }
   },
+  "face_frame": {
+    "enabled": true,
+    "thickness_mm": 19.0,
+    "stile_left_mm": 38.0,
+    "stile_right_mm": 38.0,
+    "rail_top_mm": 38.0,
+    "rail_bottom_mm": 38.0,
+    "mid_stile_mm": 0.0,
+    "mid_rail_mm": 0.0,
+    "reveal_mm": 2.0,
+    "overlay_mm": 12.7,
+    "layout": [
+      { "kind": "double_doors" }
+    ]
+  },
   "constraints": {
     "min_door_leaf_width_mm": 140
   }

--- a/aicabinets/face_frame.rb
+++ b/aicabinets/face_frame.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+module AICabinets
+  module FaceFrame
+    module_function
+
+    LAYOUT_KINDS = %w[double_doors drawer_stack].freeze
+    DEFAULT_LAYOUT = [{ kind: 'double_doors' }].freeze
+    DEFAULTS_MM = {
+      enabled: true,
+      thickness_mm: 19.0,
+      stile_left_mm: 38.0,
+      stile_right_mm: 38.0,
+      rail_top_mm: 38.0,
+      rail_bottom_mm: 38.0,
+      mid_stile_mm: 0.0,
+      mid_rail_mm: 0.0,
+      reveal_mm: 2.0,
+      overlay_mm: 12.7,
+      layout: DEFAULT_LAYOUT
+    }.freeze
+
+    BOUNDS = {
+      thickness_mm: 12.0..25.0,
+      stile_left_mm: 25.0..76.0,
+      stile_right_mm: 25.0..76.0,
+      rail_top_mm: 25.0..76.0,
+      rail_bottom_mm: 25.0..76.0,
+      mid_stile_mm: 25.0..76.0,
+      mid_rail_mm: 25.0..76.0,
+      reveal_mm: 1.0..3.0,
+      overlay_mm: 6.0..19.0
+    }.freeze
+
+    def defaults_mm
+      deep_dup(DEFAULTS_MM)
+    end
+
+    def normalize(raw, defaults: defaults_mm)
+      normalized = deep_dup(defaults || defaults_mm)
+      return [normalized, []] unless raw.is_a?(Hash)
+
+      errors = []
+      enabled_value = raw.key?(:enabled) ? raw[:enabled] : raw['enabled']
+      normalized[:enabled] = !!enabled_value unless enabled_value.nil?
+
+      numeric_keys.each do |key|
+        next unless raw.key?(key) || raw.key?(key.to_s)
+
+        value = raw[key] || raw[key.to_s]
+        numeric = parse_numeric(value)
+        if numeric.nil?
+          errors << "face_frame.#{key} must be a number"
+          next
+        end
+
+        normalized[key] = numeric.to_f
+      end
+
+      layout_value = raw[:layout] || raw['layout']
+      layout, layout_errors = normalize_layout(layout_value, defaults[:layout])
+      normalized[:layout] = layout
+      errors.concat(layout_errors)
+
+      [normalized, errors]
+    end
+
+    def validate(face_frame)
+      return ['face_frame must be an object'] unless face_frame.is_a?(Hash)
+
+      errors = []
+
+      BOUNDS.each do |key, range|
+        value = face_frame[key]
+        next unless value.is_a?(Numeric)
+        next if zero_optional?(key, value)
+        next if range.cover?(value)
+
+        errors << format(
+          'face_frame.%<field>s must be between %<min>.1f mm and %<max>.1f mm',
+          field: key,
+          min: range.begin,
+          max: range.end
+        )
+      end
+
+      layout_errors = validate_layout(face_frame[:layout])
+      errors.concat(layout_errors)
+
+      errors
+    end
+
+    def merge(defaults, overrides)
+      normalized_defaults = defaults.is_a?(Hash) ? defaults : defaults_mm
+      merged = deep_dup(normalized_defaults)
+      return merged unless overrides.is_a?(Hash)
+
+      sanitized, = normalize(overrides, defaults: merged)
+      deep_dup(sanitized)
+    end
+
+    def migrate_params!(params, defaults:, schema_version: nil)
+      params[:schema_version] ||= schema_version if schema_version
+
+      defaults_face_frame = defaults.is_a?(Hash) ? (defaults[:face_frame] || defaults['face_frame']) : nil
+      fallback_face_frame = defaults_face_frame || defaults_mm
+
+      face_frame_raw = params[:face_frame] || params['face_frame']
+      face_frame, = normalize(face_frame_raw, defaults: fallback_face_frame)
+      params[:face_frame] = face_frame
+      params.delete('face_frame')
+
+      params
+    end
+
+    def build_overrides_payload(face_frame)
+      return {} unless face_frame.is_a?(Hash)
+
+      normalized, errors = normalize(face_frame, defaults: defaults_mm)
+      return {} if errors.any?
+
+      payload = {}
+      payload['enabled'] = !!normalized[:enabled]
+
+      numeric_keys.each do |key|
+        payload[key.to_s] = normalized[key]
+      end
+
+      payload['layout'] = normalized[:layout].map { |entry| stringify_layout(entry) }
+      payload
+    end
+
+    def deep_dup(value)
+      case value
+      when Hash
+        value.each_with_object({}) { |(key, element), memo| memo[key] = deep_dup(element) }
+      when Array
+        value.map { |element| deep_dup(element) }
+      else
+        value
+      end
+    end
+
+    def numeric_keys
+      %i[
+        thickness_mm
+        stile_left_mm
+        stile_right_mm
+        rail_top_mm
+        rail_bottom_mm
+        mid_stile_mm
+        mid_rail_mm
+        reveal_mm
+        overlay_mm
+      ]
+    end
+    private_class_method :numeric_keys
+
+    def normalize_layout(raw, defaults_layout)
+      fallback = defaults_layout.is_a?(Array) ? defaults_layout : DEFAULT_LAYOUT
+      return [deep_dup(fallback), []] if raw.nil?
+
+      unless raw.is_a?(Array)
+        return [deep_dup(fallback), ['face_frame.layout must be an array']]
+      end
+
+      errors = []
+      normalized = raw.each_with_index.map do |entry, index|
+        unless entry.is_a?(Hash)
+          errors << "face_frame.layout[#{index}] must be an object"
+          next
+        end
+
+        symbolize_keys(entry)
+      end.compact
+
+      normalized = deep_dup(fallback) if normalized.empty?
+      [normalized, errors]
+    end
+    private_class_method :normalize_layout
+
+    def validate_layout(layout)
+      return ['face_frame.layout must be an array'] unless layout.is_a?(Array)
+
+      errors = []
+      layout.each_with_index do |entry, index|
+        unless entry.is_a?(Hash)
+          errors << "face_frame.layout[#{index}] must be an object"
+          next
+        end
+
+        kind = entry[:kind] || entry['kind']
+        unless LAYOUT_KINDS.include?(kind)
+          errors << "face_frame.layout[#{index}].kind must be one of #{LAYOUT_KINDS.join(', ')}"
+          next
+        end
+
+        if kind == 'drawer_stack'
+          drawers = entry[:drawers] || entry['drawers']
+          unless drawers.is_a?(Integer) && drawers.positive?
+            errors << "face_frame.layout[#{index}].drawers must be a positive integer"
+          end
+        end
+      end
+
+      errors
+    end
+    private_class_method :validate_layout
+
+    def zero_optional?(key, value)
+      %i[mid_stile_mm mid_rail_mm].include?(key) && value.to_f.zero?
+    end
+    private_class_method :zero_optional?
+
+    def stringify_layout(entry)
+      return entry unless entry.is_a?(Hash)
+
+      entry.each_with_object({}) do |(key, value), memo|
+        memo[key.to_s] = value
+      end
+    end
+    private_class_method :stringify_layout
+
+    def parse_numeric(value)
+      case value
+      when Numeric
+        return nil unless value.finite?
+
+        value.to_f
+      when String
+        stripped = value.strip
+        return nil if stripped.empty?
+
+        Float(stripped)
+      end
+    rescue ArgumentError, TypeError
+      nil
+    end
+    private_class_method :parse_numeric
+
+    def symbolize_keys(value)
+      return value unless value.is_a?(Hash)
+
+      value.each_with_object({}) do |(key, element), memo|
+        memo[key.to_sym] = element
+      end
+    end
+    private_class_method :symbolize_keys
+  end
+end

--- a/aicabinets/ui/dialogs/insert_base_cabinet_dialog.rb
+++ b/aicabinets/ui/dialogs/insert_base_cabinet_dialog.rb
@@ -4,7 +4,9 @@ require 'json'
 require 'digest'
 
 require 'aicabinets/defaults'
+require 'aicabinets/face_frame'
 require 'aicabinets/params_sanitizer'
+require 'aicabinets/version'
 require 'aicabinets/ui/localization'
 require 'aicabinets/ui/dialog_console_bridge'
 require 'aicabinets/ui_visibility'
@@ -1862,6 +1864,13 @@ module AICabinets
           params = JSON.parse(params_json, symbolize_names: true)
           defaults = AICabinets::Defaults.load_effective_mm
           AICabinets::ParamsSanitizer.sanitize!(params, global_defaults: defaults)
+          AICabinets::FaceFrame.migrate_params!(
+            params,
+            defaults: defaults,
+            schema_version: AICabinets::PARAMS_SCHEMA_VERSION
+          )
+          face_frame_errors = AICabinets::FaceFrame.validate(params[:face_frame])
+          warn("AI Cabinets: stored cabinet face_frame invalid: #{face_frame_errors.join('; ')}") if face_frame_errors.any?
           params
         rescue JSON::ParserError => e
           warn("AI Cabinets: Unable to parse stored cabinet parameters: #{e.message}")

--- a/aicabinets/version.rb
+++ b/aicabinets/version.rb
@@ -2,4 +2,5 @@
 
 module AICabinets
   VERSION = '0.1.0'.freeze
+  PARAMS_SCHEMA_VERSION = 2
 end

--- a/test/test_face_frame.rb
+++ b/test/test_face_frame.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+
+require 'aicabinets/face_frame'
+
+class FaceFrameTest < Minitest::Test
+  def test_defaults_mm_matches_expected_values
+    defaults = AICabinets::FaceFrame.defaults_mm
+
+    assert_equal(true, defaults[:enabled])
+    assert_in_delta(19.0, defaults[:thickness_mm])
+    assert_equal([{ kind: 'double_doors' }], defaults[:layout])
+  end
+
+  def test_normalize_and_validate_allows_zero_mid_members
+    normalized, errors = AICabinets::FaceFrame.normalize({ mid_stile_mm: 0, mid_rail_mm: 0 }, defaults: {})
+    assert_empty(errors)
+
+    validation_errors = AICabinets::FaceFrame.validate(normalized)
+    assert_empty(validation_errors)
+  end
+
+  def test_validate_rejects_out_of_range_values
+    defaults = AICabinets::FaceFrame.defaults_mm
+    normalized, errors = AICabinets::FaceFrame.normalize({ thickness_mm: 9, overlay_mm: 40 }, defaults: defaults)
+    assert_empty(errors)
+
+    validation_errors = AICabinets::FaceFrame.validate(normalized)
+    refute_empty(validation_errors)
+    assert_includes(validation_errors.first, 'thickness_mm')
+  end
+
+  def test_validate_rejects_unknown_layout_kind
+    defaults = AICabinets::FaceFrame.defaults_mm
+    normalized, errors = AICabinets::FaceFrame.normalize({ layout: [{ kind: 'unknown' }] }, defaults: defaults)
+    assert_empty(errors)
+
+    validation_errors = AICabinets::FaceFrame.validate(normalized)
+    refute_empty(validation_errors)
+    assert_includes(validation_errors.first, 'layout[0].kind')
+  end
+end

--- a/test/test_face_frame_params.rb
+++ b/test/test_face_frame_params.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+$LOAD_PATH.unshift(File.expand_path('support', __dir__))
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+
+module Geom
+  class Point3d; end
+
+  class Transformation
+    def initialize(*); end
+  end
+end
+
+require 'aicabinets/ops/insert_base_cabinet'
+
+class FaceFrameParamsIntegrationTest < Minitest::Test
+  def setup
+    @defaults = AICabinets::Defaults.load_mm
+  end
+
+  def test_schema_version_and_face_frame_defaults_added
+    sanitized = AICabinets::Ops::InsertBaseCabinet.send(:validate_params!, @defaults)
+
+    assert_equal(AICabinets::PARAMS_SCHEMA_VERSION, sanitized[:schema_version])
+    assert_equal(@defaults[:face_frame], sanitized[:face_frame])
+  end
+
+  def test_invalid_face_frame_rejected
+    params = Marshal.load(Marshal.dump(@defaults))
+    params[:face_frame][:thickness_mm] = 9.0
+
+    error = assert_raises(ArgumentError) do
+      AICabinets::Ops::InsertBaseCabinet.send(:validate_params!, params)
+    end
+
+    assert_includes(error.message, 'thickness_mm')
+  end
+end


### PR DESCRIPTION
Summary:
- Added a dedicated face_frame schema with default presets (double doors), validation bounds, and serialization support, and bumped the params schema version to carry the new section.
- Integrated face_frame defaults into shipped/user override loading, merge, and UI/ops migration so legacy params are upgraded with defaults while invalid inputs fail validation.
- Added unit coverage for the new schema, migration, and validation rules, including schema_version stamping on persisted params.

Closes #189

Testing:
- ruby -c aicabinets.rb && find aicabinets -type f -name '*.rb' -print0 | xargs -0 -n1 ruby -c
- ruby -Itest -Itest/support test/test_face_frame.rb -v
- ruby -Itest -Itest/support test/test_defaults.rb test/test_overrides.rb test/test_face_frame_params.rb -v

Acceptance Criteria:
- [x] Defaults include face_frame with enabled true and Option A presets (unit: DefaultsLoaderTest#test_load_mm_returns_canonical_defaults)
- [x] Legacy params migrate to include face_frame and schema_version (FaceFrameParamsIntegrationTest)
- [x] Invalid face_frame values raise validation errors (FaceFrameParamsIntegrationTest#test_invalid_face_frame_rejected; FaceFrameTest)
- [x] Layout validation restricts to MVP presets (FaceFrameTest#test_validate_rejects_unknown_layout_kind)
- [x] Overrides merge order preserved with face_frame participation (OverridesTest#test_load_effective_mm_merges_face_frame_overrides)

Follow-ups / Open questions:
- None at this time.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4019b2c48333bcee7681f21a0d34)