### PR TITLE
[schema] Add v2 params with `cabinet_type` + style blocks; persist on definition

### DIFF
--- a/aicabinets/data/defaults.json
+++ b/aicabinets/data/defaults.json
@@ -1,9 +1,10 @@
 {
-  "version": 1,
+  "version": 2,
   "cabinet_base": {
     "width_mm": 600,
     "depth_mm": 600,
     "height_mm": 720,
+    "overlay_mm": 0,
     "panel_thickness_mm": 18,
     "toe_kick_height_mm": 100,
     "toe_kick_depth_mm": 50,

--- a/aicabinets/defaults.rb
+++ b/aicabinets/defaults.rb
@@ -14,7 +14,7 @@ module AICabinets
     DEFAULTS_PATH = File.join(DATA_DIR, 'defaults.json')
     OVERRIDES_PATH = File.join(USER_DIR, 'overrides.json')
     OVERRIDES_TEMP_PATH = "#{OVERRIDES_PATH}.tmp"
-    DEFAULT_VERSION = 1
+    DEFAULT_VERSION = 2
     NORMALIZATION_PRECISION = 3 # store mm values with 0.001 mm precision
 
     FRONT_OPTIONS = %w[empty doors_left doors_right doors_double].freeze
@@ -58,6 +58,7 @@ module AICabinets
       width_mm: 600.0,
       depth_mm: 600.0,
       height_mm: 720.0,
+      overlay_mm: 0.0,
       panel_thickness_mm: 18.0,
       toe_kick_height_mm: 100.0,
       toe_kick_depth_mm: 50.0,

--- a/aicabinets/ops/params_schema.rb
+++ b/aicabinets/ops/params_schema.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'json'
+
+module AICabinets
+  module Ops
+    module ParamsSchema
+      module_function
+
+      DICTIONARY_NAME = 'AICabinets'
+      PARAMS_JSON_KEY = 'params_json_mm'
+      CURRENT_VERSION = 2
+      DEFAULT_CABINET_TYPE = 'base'
+      def parse_json(json)
+        return nil unless json.is_a?(String) && !json.empty?
+
+        JSON.parse(json)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def canonical_hash(params, cabinet_type: nil)
+        upgraded = upgrade_to_v2(params, cabinet_type: cabinet_type)
+        canonicalize(upgraded)
+      end
+
+      def canonical_json(params, cabinet_type: nil)
+        JSON.generate(canonical_hash(params, cabinet_type: cabinet_type))
+      end
+
+      def digest(params, cabinet_type: nil)
+        Digest::SHA256.hexdigest(canonical_json(params, cabinet_type: cabinet_type))
+      end
+
+      def digest_from_json(json, cabinet_type: nil)
+        parsed = parse_json(json)
+        return nil unless parsed.is_a?(Hash)
+
+        digest(parsed, cabinet_type: cabinet_type)
+      end
+
+      def upgrade_to_v2(params, cabinet_type: nil)
+        normalized = deep_copy(params || {})
+        normalized = stringify_keys(normalized)
+
+        normalized['cabinet_type'] = resolve_cabinet_type(normalized, cabinet_type)
+        normalized['schema_version'] = CURRENT_VERSION
+        normalized['overlay_mm'] = normalize_length_value(normalized, 'overlay_mm', 0.0)
+
+        ensure_style_block!(normalized)
+      end
+
+      def stringify_keys(value)
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, element), memo|
+            memo[key.to_s] = stringify_keys(element)
+          end
+        when Array
+          value.map { |element| stringify_keys(element) }
+        else
+          value
+        end
+      end
+      private_class_method :stringify_keys
+
+      def canonicalize(value)
+        case value
+        when Hash
+          value.keys.sort.map do |key|
+            [key.to_s, canonicalize(value[key])]
+          end.to_h
+        when Array
+          value.map { |element| canonicalize(element) }
+        else
+          value
+        end
+      end
+      private_class_method :canonicalize
+
+      def deep_copy(value)
+        case value
+        when Hash
+          value.each_with_object({}) { |(key, element), memo| memo[key] = deep_copy(element) }
+        when Array
+          value.map { |element| deep_copy(element) }
+        else
+          value
+        end
+      end
+      private_class_method :deep_copy
+
+      def resolve_cabinet_type(container, override)
+        return override.to_s.strip unless override.to_s.strip.empty?
+
+        stored = container['cabinet_type']
+        return stored.to_s unless stored.nil? || stored.to_s.strip.empty?
+
+        DEFAULT_CABINET_TYPE
+      end
+      private_class_method :resolve_cabinet_type
+
+      def normalize_length_value(container, key, default)
+        return container[key] if container.key?(key)
+
+        default
+      end
+      private_class_method :normalize_length_value
+
+      def ensure_style_block!(container)
+        style_key = container['cabinet_type'] || DEFAULT_CABINET_TYPE
+        raw_style = container[style_key]
+        container[style_key] = normalize_style(raw_style)
+
+        container
+      end
+      private_class_method :ensure_style_block!
+
+      def normalize_style(raw_style)
+        case raw_style
+        when Hash
+          stringify_keys(raw_style)
+        when nil
+          {}
+        else
+          { 'legacy_value' => raw_style }
+        end
+      end
+      private_class_method :normalize_style
+    end
+  end
+end

--- a/tests/AI Cabinets/TC_SchemaV2.rb
+++ b/tests/AI Cabinets/TC_SchemaV2.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'testup/testcase'
+require_relative 'suite_helper'
+require 'digest'
+
+Sketchup.require('aicabinets/ops/insert_base_cabinet')
+Sketchup.require('aicabinets/ops/edit_base_cabinet')
+Sketchup.require('aicabinets/ops/params_schema')
+
+class TC_SchemaV2 < TestUp::TestCase
+  BASE_PARAMS_MM = {
+    width_mm: 762.0,
+    depth_mm: 600.0,
+    height_mm: 720.0,
+    overlay_mm: 0.0,
+    panel_thickness_mm: 19.0,
+    toe_kick_height_mm: 0.0,
+    toe_kick_depth_mm: 0.0,
+    toe_kick_thickness_mm: 19.0,
+    back_thickness_mm: 6.0,
+    top_thickness_mm: 19.0,
+    bottom_thickness_mm: 19.0
+  }.freeze
+
+  def setup
+    AICabinetsTestHelper.clean_model!
+  end
+
+  def teardown
+    AICabinetsTestHelper.clean_model!
+  end
+
+  def test_new_definition_uses_v2_schema
+    model = Sketchup.active_model
+    instance = AICabinets::Ops::InsertBaseCabinet.place_at_point!(
+      model: model,
+      point3d: ORIGIN,
+      params_mm: BASE_PARAMS_MM
+    )
+
+    params = AICabinetsTestHelper.params_mm_from_definition(instance)
+
+    assert_equal(2, params[:schema_version])
+    assert_equal('base', params[:cabinet_type])
+    %i[width_mm height_mm depth_mm overlay_mm].each do |key|
+      assert(params.key?(key), "Expected params to include #{key}")
+    end
+    assert_kind_of(Hash, params[:base], 'Expected base style block to be present')
+  end
+
+  def test_legacy_upgrade_on_save
+    model = Sketchup.active_model
+    instance = AICabinets::Ops::InsertBaseCabinet.place_at_point!(
+      model: model,
+      point3d: ORIGIN,
+      params_mm: BASE_PARAMS_MM
+    )
+    definition = instance.definition
+
+    legacy_params = BASE_PARAMS_MM.reject { |key, _| key == :overlay_mm }
+    legacy_json = JSON.generate(legacy_params)
+    dictionary = definition.attribute_dictionary(AICabinetsTestHelper::DICTIONARY_NAME, true)
+    dictionary[AICabinets::Ops::InsertBaseCabinet::PARAMS_JSON_KEY] = legacy_json
+    dictionary[AICabinets::Ops::InsertBaseCabinet::DEF_KEY] = 'legacy-key'
+    dictionary[AICabinets::Ops::InsertBaseCabinet::SCHEMA_VERSION_KEY] = 1
+
+    selection = model.selection
+    selection.clear
+    selection.add(instance)
+
+    updated_width_mm = BASE_PARAMS_MM[:width_mm] + 25.0
+    updated_params = BASE_PARAMS_MM.merge(width_mm: updated_width_mm)
+    result = AICabinets::Ops::EditBaseCabinet.apply_to_selection!(
+      model: model,
+      params_mm: updated_params,
+      scope: 'all'
+    )
+    assert(result[:ok], "Expected edit to succeed: #{result.inspect}")
+
+    upgraded_params = AICabinetsTestHelper.params_mm_from_definition(definition)
+    assert_equal(2, upgraded_params[:schema_version], 'Expected schema_version to upgrade to 2')
+    assert_equal('base', upgraded_params[:cabinet_type], 'Expected legacy definitions to infer base cabinet_type')
+    assert_kind_of(Hash, upgraded_params[:base], 'Expected base style block after upgrade')
+
+    tolerance_mm = AICabinetsTestHelper.mm(AICabinetsTestHelper::TOL)
+    bbox_width_mm = AICabinetsTestHelper.mm(definition.bounds.width)
+    assert_in_delta(updated_width_mm, bbox_width_mm, tolerance_mm,
+                    'Expected geometry to rebuild with updated width')
+  end
+
+  def test_upper_style_round_trip
+    model = Sketchup.active_model
+    definitions = model.definitions
+    definition = definitions.add('AI Cabinets Upper Cabinet')
+
+    params = {
+      schema_version: 2,
+      cabinet_type: 'upper',
+      width_mm: 762.0,
+      height_mm: 762.0,
+      depth_mm: 305.0,
+      overlay_mm: 2.0,
+      upper: { num_shelves: 2, has_back: true }
+    }
+
+    json = AICabinets::Ops::ParamsSchema.canonical_json(params, cabinet_type: 'upper')
+    def_key = Digest::SHA256.hexdigest(json)
+    AICabinets::Ops::InsertBaseCabinet.__send__(
+      :assign_definition_attributes,
+      definition,
+      def_key,
+      json
+    )
+
+    round_tripped = AICabinetsTestHelper.params_mm_from_definition(definition)
+    assert_equal('upper', round_tripped[:cabinet_type])
+    assert_equal(2, round_tripped[:schema_version])
+    assert_equal({ num_shelves: 2, has_back: true }, round_tripped[:upper])
+  end
+
+  def test_unknown_keys_preserved_through_edit
+    model = Sketchup.active_model
+    params_with_extra = BASE_PARAMS_MM.merge(custom_block: { note: 'keep_me' })
+    instance = AICabinets::Ops::InsertBaseCabinet.place_at_point!(
+      model: model,
+      point3d: ORIGIN,
+      params_mm: params_with_extra
+    )
+
+    selection = model.selection
+    selection.clear
+    selection.add(instance)
+
+    updated_params = params_with_extra.merge(width_mm: BASE_PARAMS_MM[:width_mm] + 10.0)
+    result = AICabinets::Ops::EditBaseCabinet.apply_to_selection!(
+      model: model,
+      params_mm: updated_params,
+      scope: 'all'
+    )
+    assert(result[:ok], "Expected edit to succeed: #{result.inspect}")
+
+    stored_params = AICabinetsTestHelper.params_mm_from_definition(instance)
+    assert_equal('keep_me', stored_params.dig(:custom_block, :note))
+  end
+
+  def test_params_not_stored_on_instance
+    model = Sketchup.active_model
+    instance = AICabinets::Ops::InsertBaseCabinet.place_at_point!(
+      model: model,
+      point3d: ORIGIN,
+      params_mm: BASE_PARAMS_MM
+    )
+
+    dictionary = instance.attribute_dictionary(AICabinetsTestHelper::DICTIONARY_NAME)
+    assert_nil(dictionary&.[]('params_json_mm'), 'Expected params_json_mm to be stored only on the definition')
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared ParamsSchema helper that canonicalizes params to schema v2 with cabinet_type, overlay_mm, and a style block per cabinet type
- upgrade insert/edit flows to persist the canonical v2 JSON on component definitions while matching legacy definitions by recomputed digests
- refresh defaults/versioning to default overlay_mm support and add targeted TestUp coverage for schema v2 behaviors and migrations

## Design vs Implementation
- **Design intent:** keep canonical parameters on the ComponentDefinition with a versioned schema that tags cabinet_type and nests style-specific data.
- **Implementation:** centralized normalization (ParamsSchema) enforces schema_version=2, inserts cabinet_type-specific style blocks, and serializes mm-only values; insert/edit operations compute def_keys from this canonical JSON and rewrite definition attributes accordingly. Legacy definitions are matched via recomputed digests and upgraded lazily on write.
- **Migration approach:** lazy upgrade—legacy params_json without cabinet_type are parsed when touched, canonicalized to v2 with inferred cabinet_type="base", and written back during edit/insert flows.
- **JSON shape:** single object with top-level schema_version/cabinet_type/core `_mm` fields plus a nested style object keyed by cabinet_type (e.g., `base`, `upper`).

## Acceptance Criteria
- [x] New definition uses v2 — `TC_SchemaV2#test_new_definition_uses_v2_schema`
- [x] Legacy upgrade on save — `TC_SchemaV2#test_legacy_upgrade_on_save`
- [x] Edit scope — instance — `TC_EditScope#test_edit_scope_instance_only`
- [x] Edit scope — all — `TC_EditScope#test_edit_scope_all_instances`
- [x] Upper style round-trip — `TC_SchemaV2#test_upper_style_round_trip`
- [x] Units & keys policy — `TC_SchemaV2#test_new_definition_uses_v2_schema` (overlay_mm) plus canonicalization of `_mm` lengths
- [x] Unknown keys preserved — `TC_SchemaV2#test_unknown_keys_preserved_through_edit`
- [x] No instance-level drift — `TC_SchemaV2#test_params_not_stored_on_instance`

Closes #181

## Follow-ups / Open Questions
- Align TYPE metadata with additional cabinet types once non-base generators are introduced.
- Consider broader mm-key assertions if new length fields are added outside current sanitizers.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6763e4e48333b326d2f14c0e431d)