### PR TITLE
[metadata] Five‑piece door parts — attributes, tags & BOM hook

### DIFF
--- a/aicabinets/bom.rb
+++ b/aicabinets/bom.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'sketchup.rb'
+
+Sketchup.require('aicabinets/metadata')
+Sketchup.require('aicabinets/generator/fronts')
+
+module AICabinets
+  module BOM
+    module_function
+
+    DICTIONARY_NAME = AICabinets::Metadata::DICTIONARY_NAME
+    FRONT_TAG_NAME = AICabinets::Generator::Fronts::FRONTS_TAG_NAME
+
+    def parts_for(definition:)
+      normalized = normalize_definition(definition)
+      return [] unless normalized
+
+      normalized.entities.grep(Sketchup::Group).filter_map do |group|
+        next unless valid_part?(group)
+
+        part_definition = group.definition
+        dictionary = part_definition.attribute_dictionary(DICTIONARY_NAME)
+        next unless dictionary
+
+        part_type = dictionary['part_type']
+        joint_type = dictionary['joint_type']
+        panel_type = dictionary['panel_type']
+        schema_version = dictionary['schema_version']
+        next unless part_type && joint_type && panel_type && schema_version
+
+        {
+          part_type: part_type.to_sym,
+          joint_type: joint_type.to_s,
+          panel_type: panel_type.to_s
+        }
+      end
+    end
+
+    def normalize_definition(target)
+      definition_class = Sketchup.const_defined?(:ComponentDefinition) ? Sketchup::ComponentDefinition : nil
+      instance_class = Sketchup.const_defined?(:ComponentInstance) ? Sketchup::ComponentInstance : nil
+
+      case target
+      when definition_class
+        target.valid? ? target : nil
+      when instance_class
+        return nil unless target.valid?
+
+        target.definition if target.respond_to?(:definition)
+      else
+        nil
+      end
+    end
+    private_class_method :normalize_definition
+
+    def valid_part?(group)
+      return false unless group&.valid?
+      return false unless group.respond_to?(:layer)
+
+      layer = group.layer
+      return false unless layer.respond_to?(:name)
+      return false unless layer.name == FRONT_TAG_NAME
+
+      definition = group.definition if group.respond_to?(:definition)
+      definition&.valid?
+    rescue StandardError
+      false
+    end
+    private_class_method :valid_part?
+  end
+end

--- a/aicabinets/loader.rb
+++ b/aicabinets/loader.rb
@@ -6,6 +6,8 @@ module AICabinets
     Sketchup.require('aicabinets/validation_error')
     Sketchup.require('aicabinets/capabilities')
     Sketchup.require('aicabinets/appearance')
+    Sketchup.require('aicabinets/metadata')
+    Sketchup.require('aicabinets/bom')
     Sketchup.require('aicabinets/params/five_piece')
     Sketchup.require('aicabinets/geometry/five_piece')
     Sketchup.require('aicabinets/geometry/five_piece_panel')

--- a/aicabinets/metadata.rb
+++ b/aicabinets/metadata.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'sketchup.rb'
+
+Sketchup.require('aicabinets/tags')
+Sketchup.require('aicabinets/generator/fronts')
+
+module AICabinets
+  module Metadata
+    module_function
+
+    DICTIONARY_NAME = 'AICabinets'.freeze
+    SCHEMA_VERSION = 1
+
+    STILE_NAMES = ['Door-Stile-L', 'Door-Stile-R'].freeze
+    RAIL_NAMES = ['Door-Rail-Bottom', 'Door-Rail-Top'].freeze
+    PANEL_NAME = 'Door-Panel'.freeze
+
+    def write_five_piece!(definition:, params:, parts:)
+      normalized_definition = normalize_definition(definition)
+      return { applied: false, warnings: ['Invalid definition'] } unless normalized_definition
+
+      joint_type = string_param(params, :joint_type)
+      panel_type = string_param(params, :panel_style)
+
+      return { applied: false, warnings: ['Missing joint_type or panel_style'] } unless joint_type && panel_type
+
+      parts ||= {}
+      stiles = Array(parts[:stiles]).compact
+      rails = Array(parts[:rails]).compact
+      panel = parts[:panel]
+
+      return { applied: false, warnings: ['No five-piece parts provided'] } if stiles.empty? && rails.empty? && panel.nil?
+
+      model = normalized_definition.model
+      tag = AICabinets::Tags.ensure_fronts!(model: model) if model
+
+      apply_metadata(stiles, part_type: 'stile', joint_type: joint_type, panel_type: panel_type, names: STILE_NAMES, tag: tag)
+      apply_metadata(rails, part_type: 'rail', joint_type: joint_type, panel_type: panel_type, names: RAIL_NAMES, tag: tag)
+      apply_metadata(Array(panel).compact, part_type: 'panel', joint_type: joint_type, panel_type: panel_type, names: [PANEL_NAME], tag: tag)
+
+      { applied: true, warnings: [] }
+    rescue StandardError => error
+      { applied: false, warnings: [error.message] }
+    end
+
+    def string_param(params, key)
+      return unless params.respond_to?(:[])
+
+      value = params[key]
+      value = params[key.to_s] if value.nil? && key.respond_to?(:to_s)
+      return unless value
+
+      value.to_s
+    end
+    private_class_method :string_param
+
+    def normalize_definition(target)
+      definition_class = Sketchup.const_defined?(:ComponentDefinition) ? Sketchup::ComponentDefinition : nil
+      instance_class = Sketchup.const_defined?(:ComponentInstance) ? Sketchup::ComponentInstance : nil
+
+      case target
+      when definition_class
+        target.valid? ? target : nil
+      when instance_class
+        return nil unless target.valid?
+
+        target.make_unique if target.respond_to?(:make_unique)
+        target.definition if target.respond_to?(:definition)
+      else
+        nil
+      end
+    end
+    private_class_method :normalize_definition
+
+    def apply_metadata(groups, part_type:, joint_type:, panel_type:, names:, tag:)
+      groups.each_with_index do |group, index|
+        next unless group&.valid?
+
+        definition = group_definition(group)
+        next unless definition
+
+        name = names[index] || names.last || default_name_for(part_type)
+        apply_names(group, definition, name)
+        assign_tag(group, tag)
+
+        dictionary = definition.attribute_dictionary(DICTIONARY_NAME, true)
+        dictionary['part_type'] = part_type
+        dictionary['joint_type'] = joint_type
+        dictionary['panel_type'] = panel_type
+        dictionary['schema_version'] = SCHEMA_VERSION
+      end
+    end
+    private_class_method :apply_metadata
+
+    def group_definition(group)
+      definition = group.respond_to?(:definition) ? group.definition : nil
+      return unless definition&.valid?
+
+      definition
+    end
+    private_class_method :group_definition
+
+    def default_name_for(part_type)
+      "Door-#{part_type.capitalize}"
+    end
+    private_class_method :default_name_for
+
+    def apply_names(group, definition, name)
+      assign_name(group, name)
+      assign_name(definition, name)
+    end
+    private_class_method :apply_names
+
+    def assign_name(entity, name)
+      return unless entity.respond_to?(:name=)
+
+      entity.name = name
+    rescue StandardError
+      nil
+    end
+    private_class_method :assign_name
+
+    def assign_tag(group, tag)
+      return unless group.respond_to?(:layer=)
+      return unless tag
+
+      group.layer = tag
+    rescue StandardError
+      nil
+    end
+    private_class_method :assign_tag
+  end
+end

--- a/aicabinets/tags.rb
+++ b/aicabinets/tags.rb
@@ -91,6 +91,10 @@ module AICabinets
       end
     end
 
+    def ensure_fronts!(model:)
+      ensure_owned_tag(model, 'AICabinets/Fronts')
+    end
+
     def supports_tag_folders?(layers)
       defined?(Sketchup::LayerFolder) &&
         layers.respond_to?(:add_folder) &&

--- a/aicabinets/ui/dialogs/fronts_dialog.rb
+++ b/aicabinets/ui/dialogs/fronts_dialog.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'aicabinets/geometry/five_piece'
 require 'aicabinets/geometry/five_piece_panel'
 require 'aicabinets/generator/fronts'
+require 'aicabinets/metadata'
 require 'aicabinets/ops/tags'
 require 'aicabinets/ops/units'
 require 'aicabinets/params/five_piece'
@@ -390,13 +391,23 @@ module AICabinets
           open_w_mm ||= width_mm - (2.0 * params[:stile_width_mm].to_f)
           open_h_mm ||= height_mm - (2.0 * params[:rail_width_mm].to_f)
 
-          AICabinets::Geometry::FivePiecePanel.build_panel!(
+          panel_result = AICabinets::Geometry::FivePiecePanel.build_panel!(
             target: definition,
             params: params,
             style: params[:panel_style],
             cove_radius_mm: params[:panel_cove_radius_mm],
             open_w_mm: open_w_mm,
             open_h_mm: open_h_mm
+          )
+
+          AICabinets::Metadata.write_five_piece!(
+            definition: definition,
+            params: params,
+            parts: {
+              stiles: frame_result[:stiles],
+              rails: frame_result[:rails],
+              panel: panel_result[:panel]
+            }
           )
         end
         module_function :regenerate_front_impl

--- a/tests/AI Cabinets/TC_FivePieceMetadataBOM.rb
+++ b/tests/AI Cabinets/TC_FivePieceMetadataBOM.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'testup/testcase'
+require_relative 'suite_helper'
+
+Sketchup.require('aicabinets/metadata')
+Sketchup.require('aicabinets/bom')
+Sketchup.require('aicabinets/geometry/five_piece')
+Sketchup.require('aicabinets/geometry/five_piece_panel')
+Sketchup.require('aicabinets/params/five_piece')
+
+class TC_FivePieceMetadataBOM < TestUp::TestCase
+  OPENING_W_MM = 620.0
+  OPENING_H_MM = 740.0
+  BASE_PARAMS = AICabinets::Params::FivePiece.defaults.merge(
+    door_thickness_mm: 19.0,
+    groove_width_mm: 18.0
+  ).freeze
+
+  def setup
+    AICabinetsTestHelper.clean_model!
+  end
+
+  def teardown
+    AICabinetsTestHelper.clean_model!
+  end
+
+  def test_attributes_on_all_parts
+    definition, parts = build_door_with_metadata
+
+    part_definitions(parts).each do |component_def|
+      dictionary = component_def.attribute_dictionary(AICabinets::Metadata::DICTIONARY_NAME)
+      refute_nil(dictionary, 'Expected metadata dictionary to exist')
+
+      assert_includes(%w[stile rail panel], dictionary['part_type'])
+      assert_equal('cope_stick', dictionary['joint_type'])
+      assert_equal('flat', dictionary['panel_type'])
+      assert_equal(AICabinets::Metadata::SCHEMA_VERSION, dictionary['schema_version'])
+    end
+  end
+
+  def test_tags_applied_to_all_parts
+    definition, parts = build_door_with_metadata
+
+    parts.values.flatten.compact.each do |group|
+      assert_equal('AICabinets/Fronts', group.layer.name)
+    end
+
+    definition.entities.grep(Sketchup::Group).each do |group|
+      assert_equal('AICabinets/Fronts', group.layer.name)
+    end
+  end
+
+  def test_stable_names_without_dimensions
+    definition, parts = build_door_with_metadata
+    expected_names = %w[Door-Stile-L Door-Stile-R Door-Rail-Bottom Door-Rail-Top Door-Panel]
+
+    names = (parts.values.flatten.compact.map(&:name) + part_definitions(parts).map(&:name)).uniq
+    assert_equal(expected_names.sort, names.sort)
+    names.each do |name|
+      refute_match(/\d/, name, 'Names must not embed dimensions')
+    end
+  end
+
+  def test_metadata_refreshes_with_joint_and_panel_changes
+    params = BASE_PARAMS.dup
+    definition, = build_door_with_metadata(params: params)
+
+    params[:joint_type] = 'miter'
+    params[:panel_style] = 'raised'
+
+    frame_result = AICabinets::Geometry::FivePiece.build_frame!(
+      target: definition,
+      params: params,
+      open_w_mm: OPENING_W_MM,
+      open_h_mm: OPENING_H_MM
+    )
+
+    panel_result = AICabinets::Geometry::FivePiecePanel.build_panel!(
+      target: definition,
+      params: params,
+      style: params[:panel_style],
+      open_w_mm: OPENING_W_MM,
+      open_h_mm: OPENING_H_MM
+    )
+
+    AICabinets::Metadata.write_five_piece!(
+      definition: definition,
+      params: params,
+      parts: {
+        stiles: frame_result[:stiles],
+        rails: frame_result[:rails],
+        panel: panel_result[:panel]
+      }
+    )
+
+    part_definitions(stiles: frame_result[:stiles], rails: frame_result[:rails], panel: panel_result[:panel]).each do |component_def|
+      dictionary = component_def.attribute_dictionary(AICabinets::Metadata::DICTIONARY_NAME)
+      assert_equal('miter', dictionary['joint_type'])
+      assert_equal('raised', dictionary['panel_type'])
+    end
+
+    names = definition.entities.grep(Sketchup::Group).map(&:name).uniq
+    assert_equal(%w[Door-Rail-Bottom Door-Rail-Top Door-Stile-L Door-Stile-R Door-Panel].sort, names.sort)
+  end
+
+  def test_frame_only_metadata_and_bom
+    definition, parts = build_door_with_metadata(include_panel: false)
+
+    dictionary_values = part_definitions(parts).map do |component_def|
+      component_def.attribute_dictionary(AICabinets::Metadata::DICTIONARY_NAME)
+    end
+    dictionary_values.each do |dictionary|
+      assert_equal('flat', dictionary['panel_type'])
+    end
+
+    rows = AICabinets::BOM.parts_for(definition: definition)
+    counts = rows.each_with_object(Hash.new(0)) { |row, memo| memo[row[:part_type]] += 1 }
+    assert_equal({ stile: 2, rail: 2 }, counts)
+  end
+
+  def test_bom_grouping_counts
+    definition, = build_door_with_metadata
+
+    rows = AICabinets::BOM.parts_for(definition: definition)
+    counts = rows.each_with_object(Hash.new(0)) { |row, memo| memo[row[:part_type]] += 1 }
+
+    assert_equal({ stile: 2, rail: 2, panel: 1 }, counts)
+  end
+
+  def test_instance_only_metadata_is_isolated
+    definition, = build_door_with_metadata
+    model = Sketchup.active_model
+    instance_one = model.entities.add_instance(definition, Geom::Transformation.new)
+    instance_two = model.entities.add_instance(definition, Geom::Transformation.translation([100.mm, 0, 0]))
+
+    updated_params = BASE_PARAMS.merge(joint_type: 'miter', panel_style: 'reverse_raised')
+    frame_result = AICabinets::Geometry::FivePiece.build_frame!(
+      target: instance_one,
+      params: updated_params,
+      open_w_mm: OPENING_W_MM,
+      open_h_mm: OPENING_H_MM
+    )
+
+    panel_result = AICabinets::Geometry::FivePiecePanel.build_panel!(
+      target: instance_one,
+      params: updated_params,
+      style: updated_params[:panel_style],
+      open_w_mm: OPENING_W_MM,
+      open_h_mm: OPENING_H_MM
+    )
+
+    AICabinets::Metadata.write_five_piece!(
+      definition: instance_one,
+      params: updated_params,
+      parts: {
+        stiles: frame_result[:stiles],
+        rails: frame_result[:rails],
+        panel: panel_result[:panel]
+      }
+    )
+
+    updated_definition = instance_one.definition
+    sibling_definition = instance_two.definition
+
+    updated_dictionary = part_definitions(stiles: frame_result[:stiles], rails: frame_result[:rails], panel: panel_result[:panel]).first.attribute_dictionary(AICabinets::Metadata::DICTIONARY_NAME)
+    assert_equal('miter', updated_dictionary['joint_type'])
+    assert_equal('reverse_raised', updated_dictionary['panel_type'])
+
+    sibling_dictionaries = sibling_definition.entities.grep(Sketchup::Group).map do |group|
+      group.definition.attribute_dictionary(AICabinets::Metadata::DICTIONARY_NAME)
+    end
+    sibling_dictionaries.each do |dictionary|
+      assert_equal('cope_stick', dictionary['joint_type'])
+      assert_equal('flat', dictionary['panel_type'])
+    end
+
+    refute_equal(updated_definition, sibling_definition)
+  end
+
+  def test_slabs_are_ignored
+    model = Sketchup.active_model
+    definition = model.definitions.add('Slab Door')
+    group = definition.entities.add_group
+    face = group.entities.add_face(Geom::Point3d.new(0, 0, 0), Geom::Point3d.new(OPENING_W_MM.mm, 0, 0), Geom::Point3d.new(OPENING_W_MM.mm, 0, OPENING_H_MM.mm), Geom::Point3d.new(0, 0, OPENING_H_MM.mm))
+    face.pushpull(19.mm) if face
+
+    result = AICabinets::Metadata.write_five_piece!(definition: definition, params: { door_type: 'slab' }, parts: {})
+
+    refute(result[:applied])
+    assert_nil(definition.attribute_dictionary(AICabinets::Metadata::DICTIONARY_NAME))
+    assert_equal('Slab Door', definition.name)
+  end
+
+  private
+
+  def build_door_with_metadata(params: BASE_PARAMS, include_panel: true)
+    definition = Sketchup.active_model.definitions.add('Five-Piece Door')
+    frame_result = AICabinets::Geometry::FivePiece.build_frame!(
+      target: definition,
+      params: params,
+      open_w_mm: OPENING_W_MM,
+      open_h_mm: OPENING_H_MM
+    )
+
+    panel_result = nil
+    if include_panel
+      panel_result = AICabinets::Geometry::FivePiecePanel.build_panel!(
+        target: definition,
+        params: params,
+        style: params[:panel_style],
+        open_w_mm: OPENING_W_MM,
+        open_h_mm: OPENING_H_MM
+      )
+    end
+
+    AICabinets::Metadata.write_five_piece!(
+      definition: definition,
+      params: params,
+      parts: {
+        stiles: frame_result[:stiles],
+        rails: frame_result[:rails],
+        panel: panel_result && panel_result[:panel]
+      }
+    )
+
+    [definition, { stiles: frame_result[:stiles], rails: frame_result[:rails], panel: panel_result && panel_result[:panel] }]
+  end
+
+  def part_definitions(parts)
+    parts.values.flatten.compact.map do |group|
+      group.definition if group.respond_to?(:definition)
+    end.compact
+  end
+end


### PR DESCRIPTION
## Summary
- add a Metadata helper that stamps five-piece stiles/rails/panels with stable names, definition-level attributes, and the AICabinets/Fronts tag
- introduce a BOM.parts_for hook to read tagged five-piece parts and expose the new helpers via the loader
- wire metadata application into five-piece regeneration and add TestUp coverage for metadata refresh, BOM counts, and slab no-op

## Acceptance Criteria
- [x] AC1 – TC_FivePieceMetadataBOM#test_attributes_on_all_parts
- [x] AC2 – TC_FivePieceMetadataBOM#test_tags_applied_to_all_parts
- [x] AC3 – TC_FivePieceMetadataBOM#test_stable_names_without_dimensions
- [x] AC4 – TC_FivePieceMetadataBOM#test_metadata_refreshes_with_joint_and_panel_changes
- [x] AC5 – TC_FivePieceMetadataBOM#test_frame_only_metadata_and_bom
- [x] AC6 – TC_FivePieceMetadataBOM#test_bom_grouping_counts
- [x] AC7 – TC_FivePieceMetadataBOM#test_instance_only_metadata_is_isolated
- [x] AC8 – TC_FivePieceMetadataBOM#test_slabs_are_ignored

## Testing
- ruby -c aicabinets/metadata.rb
- ruby -c aicabinets/bom.rb
- ruby -c aicabinets/ui/dialogs/fronts_dialog.rb
- ruby -c tests/AI Cabinets/TC_FivePieceMetadataBOM.rb

## Risks & Rollback
- Minimal risk: metadata tagging could affect unintended groups; rollback by removing the Metadata.write_five_piece! invocation in fronts_dialog or gating it behind a flag.
- Closes #148.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc34f9b088333afa60e6032b5a260)