### PR TITLE
[params] Persistence & schema versioning for face_frame

### DIFF
--- a/aicabinets/commands/face_frame.rb
+++ b/aicabinets/commands/face_frame.rb
@@ -9,9 +9,19 @@ module AICabinets
       def register!(registry)
         return unless defined?(::UI::Command)
 
-        registry[:face_frame_insert] ||= build_insert_command
-        registry[:face_frame_edit] ||= build_edit_command
+        registry[:face_frame_insert] ||= insert_command
+        registry[:face_frame_edit] ||= edit_command
       end
+
+      def insert_command
+        @insert_command ||= build_insert_command
+      end
+      private_class_method :insert_command
+
+      def edit_command
+        @edit_command ||= build_edit_command
+      end
+      private_class_method :edit_command
 
       def build_insert_command
         command = ::UI::Command.new('Cabinet (Face Frame)') do

--- a/aicabinets/loader.rb
+++ b/aicabinets/loader.rb
@@ -4,6 +4,7 @@ module AICabinets
   if defined?(Sketchup)
     Sketchup.require('aicabinets/features')
     Sketchup.require('aicabinets/version')
+    Sketchup.require('aicabinets/params/persistence')
     Sketchup.require('aicabinets/metadata/tagging')
     Sketchup.require('aicabinets/metadata/naming')
     Sketchup.require('aicabinets/ops/units')

--- a/aicabinets/params/face_frame.rb
+++ b/aicabinets/params/face_frame.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'aicabinets/face_frame'
+
+module AICabinets
+  module Params
+    module FaceFrame
+      module_function
+
+      def defaults_mm
+        AICabinets::FaceFrame.defaults_mm
+      end
+
+      def normalize(raw, defaults: defaults_mm)
+        AICabinets::FaceFrame.normalize(raw, defaults:)
+      end
+
+      def validate(face_frame)
+        AICabinets::FaceFrame.validate(face_frame)
+      end
+    end
+  end
+end

--- a/aicabinets/params/persistence.rb
+++ b/aicabinets/params/persistence.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require 'aicabinets/version'
+require 'aicabinets/defaults'
+require 'aicabinets/params/face_frame'
+
+module AICabinets
+  module Params
+    DICTIONARY_NAME = 'AICabinets'.freeze
+    PARAMS_JSON_KEY = 'params_json_mm'.freeze
+
+    module_function
+
+    def read(definition)
+      raise ArgumentError, 'definition must be a SketchUp ComponentDefinition' unless
+        component_definition?(definition)
+
+      params = read_params_hash(definition)
+      migrated, = migrate!(params)
+      defaults = AICabinets::Defaults.load_effective_mm
+      merged = apply_defaults(migrated, defaults)
+      merged[:schema_version] = AICabinets::PARAMS_SCHEMA_VERSION
+      merged
+    end
+
+    def write!(definition, params)
+      raise ArgumentError, 'definition must be a SketchUp ComponentDefinition' unless
+        component_definition?(definition)
+      raise ArgumentError, 'params must be a Hash' unless params.is_a?(Hash)
+
+      normalized = deep_copy(params)
+      errors = validate_face_frame(normalized)
+      raise ArgumentError, errors.join('; ') if errors.any?
+
+      schema_version = normalized[:schema_version] || normalized['schema_version']
+      if schema_version != AICabinets::PARAMS_SCHEMA_VERSION
+        raise ArgumentError, "schema_version must be #{AICabinets::PARAMS_SCHEMA_VERSION}"
+      end
+
+      json = JSON.generate(canonicalize(normalized))
+      dictionary = definition.attribute_dictionary(DICTIONARY_NAME, true)
+      dictionary[PARAMS_JSON_KEY] = json
+      nil
+    end
+
+    def migrate!(raw_params)
+      warnings = []
+      params = raw_params.is_a?(Hash) ? deep_copy(raw_params) : {}
+      schema_version = extract_schema_version(params)
+
+      migrate_from_0_to_1!(params, warnings) if schema_version < 1
+      migrate_from_1_to_2!(params, warnings) if schema_version < 2
+      migrate_from_2_to_current!(params, warnings) if schema_version < AICabinets::PARAMS_SCHEMA_VERSION
+
+      [params, warnings]
+    end
+
+    def migrate_from_0_to_1!(params, warnings)
+      warnings << 'schema_version missing; assuming v1' unless params.key?(:schema_version) || params.key?('schema_version')
+      params[:schema_version] = 1
+      params
+    end
+    private_class_method :migrate_from_0_to_1!
+
+    def migrate_from_1_to_2!(params, _warnings)
+      params[:schema_version] = 2
+      params
+    end
+    private_class_method :migrate_from_1_to_2!
+
+    def migrate_from_2_to_current!(params, warnings)
+      defaults = Params::FaceFrame.defaults_mm
+      face_frame_raw = params[:face_frame] || params['face_frame']
+      face_frame, face_errors = Params::FaceFrame.normalize(face_frame_raw, defaults: defaults)
+      warnings.concat(face_errors) if face_errors.any?
+      params[:face_frame] = face_frame
+      params.delete('face_frame')
+      params[:schema_version] = AICabinets::PARAMS_SCHEMA_VERSION
+      params
+    end
+    private_class_method :migrate_from_2_to_current!
+
+    def apply_defaults(params, defaults)
+      merged = deep_copy(params)
+      base_defaults = defaults[:cabinet_base] || defaults['cabinet_base'] || {}
+      base_defaults.each do |key, value|
+        next if merged.key?(key) || merged.key?(key.to_s)
+
+        merged[key.to_sym] = deep_copy(value)
+      end
+
+      if merged[:face_frame].nil?
+        merged[:face_frame] = Params::FaceFrame.defaults_mm
+      else
+        face_frame_defaults = defaults[:face_frame] || defaults['face_frame'] || Params::FaceFrame.defaults_mm
+        normalized, = Params::FaceFrame.normalize(merged[:face_frame], defaults: face_frame_defaults)
+        merged[:face_frame] = normalized
+      end
+
+      merged
+    end
+    private_class_method :apply_defaults
+
+    def validate_face_frame(params)
+      face_frame = params[:face_frame] || params['face_frame']
+      defaults = Params::FaceFrame.defaults_mm
+      normalized, normalize_errors = Params::FaceFrame.normalize(face_frame, defaults: defaults)
+      validation_errors = Params::FaceFrame.validate(normalized)
+      params[:face_frame] = normalized
+      normalize_errors + validation_errors
+    end
+    private_class_method :validate_face_frame
+
+    def read_params_hash(definition)
+      dictionary = definition.attribute_dictionary(DICTIONARY_NAME)
+      return {} unless dictionary
+
+      json = dictionary[PARAMS_JSON_KEY]
+      return {} unless json.is_a?(String) && !json.empty?
+
+      JSON.parse(json, symbolize_names: true)
+    rescue JSON::ParserError
+      {}
+    end
+    private_class_method :read_params_hash
+
+    def extract_schema_version(params)
+      value = params[:schema_version] || params['schema_version']
+      return value.to_i if value.respond_to?(:to_int)
+      return value.to_i if value.is_a?(String) && value =~ /^\d+$/
+
+      0
+    end
+    private_class_method :extract_schema_version
+
+    def component_definition?(definition)
+      return false unless defined?(Sketchup)
+
+      definition.is_a?(Sketchup::ComponentDefinition)
+    end
+    private_class_method :component_definition?
+
+    def canonicalize(value)
+      case value
+      when Hash
+        value.keys.sort_by(&:to_s).each_with_object({}) do |key, memo|
+          memo[key.to_s] = canonicalize(value[key])
+        end
+      when Array
+        value.map { |item| canonicalize(item) }
+      else
+        value
+      end
+    end
+    private_class_method :canonicalize
+
+    def deep_copy(value)
+      case value
+      when Hash
+        value.each_with_object({}) do |(key, val), memo|
+          memo[key] = deep_copy(val)
+        end
+      when Array
+        value.map { |item| deep_copy(item) }
+      else
+        value
+      end
+    end
+    private_class_method :deep_copy
+  end
+end

--- a/aicabinets/rows/reflow.rb
+++ b/aicabinets/rows/reflow.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'time'
 
 Sketchup.require('aicabinets/ops/edit_base_cabinet')
+Sketchup.require('aicabinets/params/persistence')
 
 module AICabinets
   module Rows
@@ -210,11 +211,8 @@ module AICabinets
         json = dictionary[AICabinets::Ops::InsertBaseCabinet::PARAMS_JSON_KEY]
         raise RowError.new(:missing_params, 'Cabinet parameters are unavailable.') unless json.is_a?(String)
 
-        parsed = JSON.parse(json)
-        parsed.each_with_object({}) do |(key, value), memo|
-          memo[key.to_sym] = value
-        end
-      rescue JSON::ParserError
+        AICabinets::Params.read(definition)
+      rescue StandardError
         raise RowError.new(:invalid_params, 'Cabinet parameters are invalid.')
       end
       private_class_method :definition_params

--- a/aicabinets/rows/reveal.rb
+++ b/aicabinets/rows/reveal.rb
@@ -8,6 +8,7 @@ Sketchup.require('aicabinets/ops/insert_base_cabinet')
 Sketchup.require('aicabinets/ops/materials')
 Sketchup.require('aicabinets/ops/tags')
 Sketchup.require('aicabinets/metadata/tagging')
+Sketchup.require('aicabinets/params/persistence')
 
 module AICabinets
   module Rows
@@ -188,8 +189,8 @@ module AICabinets
         json = dictionary[AICabinets::Ops::InsertBaseCabinet::PARAMS_JSON_KEY]
         return unless json.is_a?(String) && !json.empty?
 
-        JSON.parse(json, symbolize_names: true)
-      rescue JSON::ParserError
+        AICabinets::Params.read(definition)
+      rescue StandardError
         nil
       end
       private_class_method :definition_params

--- a/aicabinets/ui/dialogs/insert_base_cabinet_dialog.rb
+++ b/aicabinets/ui/dialogs/insert_base_cabinet_dialog.rb
@@ -6,6 +6,7 @@ require 'sketchup.rb'
 
 require 'aicabinets/defaults'
 require 'aicabinets/face_frame'
+require 'aicabinets/params/persistence'
 require 'aicabinets/params_sanitizer'
 require 'aicabinets/version'
 require 'aicabinets/ui/localization'
@@ -2076,18 +2077,8 @@ module AICabinets
           params_json = dict[params_key]
           return unless params_json.is_a?(String) && !params_json.empty?
 
-          params = JSON.parse(params_json, symbolize_names: true)
-          defaults = AICabinets::Defaults.load_effective_mm
-          AICabinets::ParamsSanitizer.sanitize!(params, global_defaults: defaults)
-          AICabinets::FaceFrame.migrate_params!(
-            params,
-            defaults: defaults,
-            schema_version: AICabinets::PARAMS_SCHEMA_VERSION
-          )
-          face_frame_errors = AICabinets::FaceFrame.validate(params[:face_frame])
-          warn("AI Cabinets: stored cabinet face_frame invalid: #{face_frame_errors.join('; ')}") if face_frame_errors.any?
-          params
-        rescue JSON::ParserError => e
+          AICabinets::Params.read(definition)
+        rescue StandardError => e
           warn("AI Cabinets: Unable to parse stored cabinet parameters: #{e.message}")
           nil
         end

--- a/aicabinets/version.rb
+++ b/aicabinets/version.rb
@@ -2,5 +2,5 @@
 
 module AICabinets
   VERSION = '0.1.0'.freeze
-  PARAMS_SCHEMA_VERSION = 2
+  PARAMS_SCHEMA_VERSION = 3
 end

--- a/script/print_effective_defaults.rb
+++ b/script/print_effective_defaults.rb
@@ -4,8 +4,15 @@
 $LOAD_PATH.unshift(File.expand_path('..', __dir__))
 
 require 'json'
+require 'aicabinets/version'
 require 'aicabinets/defaults'
 
 effective = AICabinets::Defaults.load_effective_mm
+payload = {
+  schema_version: AICabinets::PARAMS_SCHEMA_VERSION,
+  cabinet_base: effective[:cabinet_base] || effective['cabinet_base'],
+  face_frame: effective[:face_frame] || effective['face_frame'],
+  constraints: effective[:constraints] || effective['constraints']
+}
 
-puts(JSON.pretty_generate(effective))
+puts(JSON.pretty_generate(payload))

--- a/tests/AI Cabinets/TC_ParamsPersistence.rb
+++ b/tests/AI Cabinets/TC_ParamsPersistence.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'testup/testcase'
+require_relative 'suite_helper'
+
+Sketchup.require('aicabinets/params/persistence')
+Sketchup.require('aicabinets/defaults')
+
+class TC_ParamsPersistence < TestUp::TestCase
+  include AICabinetsTestHelper
+
+  def setup
+    AICabinetsTestHelper.clean_model!
+  end
+
+  def teardown
+    AICabinetsTestHelper.clean_model!
+  end
+
+  def test_read_missing_params_creates_defaults
+    definition = create_definition
+
+    params = AICabinets::Params.read(definition)
+
+    assert_equal(AICabinets::PARAMS_SCHEMA_VERSION, params[:schema_version])
+    assert_kind_of(Hash, params[:face_frame])
+    face_frame_keys = AICabinets::FaceFrame.defaults_mm.keys.select { |key| key.to_s.end_with?('_mm') }
+    face_frame_keys.each do |key|
+      assert(params[:face_frame].key?(key), "face_frame missing #{key}")
+      assert(params[:face_frame][key].is_a?(Numeric), "face_frame #{key} should be numeric")
+    end
+  end
+
+  def test_migrate_missing_face_frame
+    legacy = {
+      'schema_version' => 1,
+      'width_mm' => 600.0,
+      'depth_mm' => 600.0,
+      'height_mm' => 720.0,
+      'panel_thickness_mm' => 18.0,
+      'toe_kick_height_mm' => 100.0,
+      'toe_kick_depth_mm' => 50.0,
+      'toe_kick_thickness_mm' => 18.0
+    }
+    definition = create_definition
+    definition.set_attribute('AICabinets', 'params_json_mm', JSON.generate(legacy))
+
+    params = AICabinets::Params.read(definition)
+
+    assert_equal(AICabinets::PARAMS_SCHEMA_VERSION, params[:schema_version])
+    assert_kind_of(Hash, params[:face_frame])
+    AICabinets::Params.write!(definition, params)
+
+    stored = JSON.parse(definition.get_attribute('AICabinets', 'params_json_mm'))
+    assert(stored.key?('face_frame'))
+    assert_equal(AICabinets::PARAMS_SCHEMA_VERSION, stored['schema_version'])
+  end
+
+  def test_copy_and_make_unique_preserves_params
+    defaults = default_params
+    definition = create_definition
+    AICabinets::Params.write!(definition, defaults)
+
+    model = Sketchup.active_model
+    instance = model.entities.add_instance(definition, Geom::Transformation.new)
+    unique_instance = model.entities.add_instance(definition, Geom::Transformation.translation([10, 0, 0]))
+    unique_instance.make_unique
+
+    unique_definition = unique_instance.definition
+    copied_params = AICabinets::Params.read(unique_definition)
+
+    assert_equal(defaults[:schema_version], copied_params[:schema_version])
+    assert_equal(defaults[:face_frame][:thickness_mm], copied_params[:face_frame][:thickness_mm])
+  end
+
+  def test_round_trip_preserves_unknown_fields
+    definition = create_definition
+    params = default_params
+    params[:custom] = { 'note' => 'keep me', future: [1, 2, 3] }
+
+    AICabinets::Params.write!(definition, params)
+    first_json = definition.get_attribute('AICabinets', 'params_json_mm')
+
+    reloaded = AICabinets::Params.read(definition)
+    AICabinets::Params.write!(definition, reloaded)
+
+    second_json = definition.get_attribute('AICabinets', 'params_json_mm')
+    assert_equal(first_json, second_json)
+  end
+
+  def test_validation_blocks_invalid_face_frame
+    definition = create_definition
+    params = default_params
+    params[:face_frame][:thickness_mm] = 9.0
+
+    assert_raises(ArgumentError) do
+      AICabinets::Params.write!(definition, params)
+    end
+
+    assert_nil(definition.get_attribute('AICabinets', 'params_json_mm'))
+  end
+
+  private
+
+  def create_definition
+    Sketchup.active_model.definitions.add('Params Test')
+  end
+
+  def default_params
+    defaults = AICabinets::Defaults.load_effective_mm
+    base = defaults[:cabinet_base].merge(face_frame: defaults[:face_frame])
+    base[:schema_version] = AICabinets::PARAMS_SCHEMA_VERSION
+    base
+  end
+end


### PR DESCRIPTION
## Summary
- store params JSON on component definitions via AICabinets::Params with schema_version tracking, migration, and face_frame defaults/validation
- migrate legacy payloads on read, fill shipped defaults, and reuse the validator before writing back compact JSON
- surface schema_version/face_frame through scripts and edit dialog lookups while adding TestUp coverage for persistence and copy/make_unique flows

## Testing
- ruby -c aicabinets.rb && find aicabinets -type f -name '*.rb' -print0 | xargs -0 -n1 ruby -c
- rubocop --parallel --display-cop-names

## AC Coverage
- AC1: TC_ParamsPersistence#test_read_missing_params_creates_defaults
- AC2: TC_ParamsPersistence#test_migrate_missing_face_frame
- AC3: TC_ParamsPersistence#test_copy_and_make_unique_preserves_params
- AC4: TC_ParamsPersistence#test_round_trip_preserves_unknown_fields
- AC5: TC_ParamsPersistence#test_validation_blocks_invalid_face_frame
- AC6: script/print_effective_defaults.rb includes schema_version and face_frame output

## Follow-ups / Open Questions
- Rollback path: revert params/persistence.rb, PARAMS_SCHEMA_VERSION bump, and loader hook to disable migrations if needed.

Closes #195

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e32c4b65883339cf7c5c088a43be7)